### PR TITLE
feat: Add upgrade command and update available message

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import sys
 
 from opensafely._vendor.jobrunner import local_run
-from opensafely import codelists, pull
+from opensafely import codelists, pull, upgrade
 
 
 __version__ = Path(__file__).parent.joinpath("VERSION").read_text().strip()
@@ -42,6 +42,18 @@ def main():
     parser_pull = subparsers.add_parser("pull", help=pull.DESCRIPTION)
     parser_pull.set_defaults(function=pull.main)
     pull.add_arguments(parser_pull)
+
+    # Add `upgrade` subcommand
+    parser_upgrade = subparsers.add_parser("upgrade", help=upgrade.DESCRIPTION)
+    parser_upgrade.set_defaults(function=upgrade.main)
+    upgrade.add_arguments(parser_upgrade)
+
+    # we version check before parse_args is called so that if a user is
+    # following recent documentation but has an old opensafely installed,
+    # there's some hint as to why their invocation is failing before being told
+    # by argparse.
+    if sys.argv[1] != "upgrade":
+        upgrade.check_version()
 
     args = parser.parse_args()
     kwargs = vars(args)

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -61,7 +61,7 @@ def get_local_images():
         check=True,
         capture_output=True,
     )
-    lines = [line for line in ps.stdout.decode('utf8').split("\n") if line.strip()]
+    lines = [line for line in ps.stdout.decode("utf8").split("\n") if line.strip()]
     return set(lines)
 
 

--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timedelta
+import subprocess
+import sys
+from pathlib import Path
+import tempfile
+
+import opensafely
+from opensafely._vendor import requests
+
+
+DESCRIPTION = "Upgrade the opensafely cli tool."
+
+CACHE_FILE = Path(tempfile.gettempdir()) / "opensafely-latest-version"
+
+
+def add_arguments(parser):
+    parser.add_argument(
+        "version",
+        nargs="?",
+        default="latest",
+        help="Version to upgrade to (default: latest)",
+    )
+
+
+def main(version):
+    if version == "latest":
+        version = get_latest_version(force=True)
+
+    if not need_to_update(version):
+        print(f"opensafely is already at version {version}")
+        return 0
+
+    pkg = "opensafely==" + version
+
+    try:
+        subprocess.run(["pip", "install", "--upgrade", pkg], check=True)
+    except subprocess.CalledProcessError as exc:
+        sys.exit(exc)
+
+
+def get_latest_version(force=False):
+    latest = None
+    two_hours_ago = datetime.utcnow() - timedelta(hours=2)
+
+    if CACHE_FILE.exists():
+        if CACHE_FILE.stat().st_mtime > two_hours_ago.timestamp():
+            latest = CACHE_FILE.read_text().strip()
+
+    if force or latest is None:
+        resp = requests.get("https://pypi.org/pypi/opensafely/json").json()
+        latest = resp["info"]["version"]
+        CACHE_FILE.write_text(latest)
+
+    return latest
+
+
+def comparable(version_string):
+    try:
+        return tuple(int(s) for s in version_string.split("."))
+    except Exception:
+        raise Exception(f"Invalid version string: {version_string}")
+
+
+def need_to_update(latest):
+    current = None
+    current = opensafely.__version__.lstrip("v")
+    return comparable(latest) > comparable(current)
+
+
+def check_version():
+    try:
+        latest = get_latest_version()
+        update = need_to_update(latest)
+        if update:
+            print(
+                f"Warning: there is a newer version of opensafely available - please run 'opensafely upgrade' to update to {latest}\n"
+            )
+        return update
+    except Exception:
+        pass  # this is an optional check, it should never stop the program

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ setup(
     packages=find_namespace_packages(exclude=["tests"]),
     include_package_data=True,
     url="https://github.com/opensafely/opensafely-cli",
+    description="Command line tool for running OpenSAFELY studies locally.",
+    license="GPLv3",
     author="OpenSAFELY",
     author_email="tech@opensafely.org",
     python_requires=">=3.7",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,67 @@
+import subprocess
+from collections import deque
+
+import pytest
+
+_actual_run = subprocess.run
+
+
+class SubprocessRunFixture(deque):
+    """Fixture for mocking subprocess.run.
+
+    Add expected calls and their responses to subprocess.run:
+
+        run.expect(['your', 'cmd', 'here'], returncode=1, stderr='error!')
+
+    And when subprocess.run is called with that command, it will return the
+    appropriate CompletedProcess object.
+
+    If your code is calling subprocess.run with check=True, pass that to the
+    expect() call too, and a CalledProcessError will be raised if the
+    returncode is not 0.
+
+        run.expect(['your', 'cmd', 'here'], check=True, returncode=1, stderr='error!')
+
+    By default, strict=True, which means all calls to subprocess.run must have
+    a matching expect(), or an AssertionError will be raised.
+
+    If strict is set to False, any unexpected calls are passed through to the
+    real subprocess.run(). This allows you to only mock some calls to
+    subprocess.run().
+    """
+
+    strict = True
+
+    def expect(self, cmd, returncode=0, stdout=None, stderr=None, check=False):
+        if check and returncode != 0:
+            value = subprocess.CalledProcessError(returncode, cmd, stdout, stderr)
+        else:
+            value = subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+        self.append((cmd, value))
+
+    def run(self, cmd, *args, **kwargs):
+        """The replacement run() function."""
+        expected, value = self.popleft()
+
+        if expected == cmd:
+            if isinstance(value, Exception):
+                raise value
+            return value
+
+        if self.strict:
+            raise AssertionError(f"run fixture got unexpected call: {cmd}")
+        else:
+            # pass through to system
+            return _actual_run(cmd, *args, **kwargs)
+
+
+@pytest.fixture
+def run(monkeypatch):
+    fixture = SubprocessRunFixture()
+    monkeypatch.setattr(subprocess, "run", fixture.run)
+    yield fixture
+    if len(fixture) != 0:
+        remaining = "\n".join(str(cmd) for cmd, _ in fixture)
+        raise AssertionError(
+            f"run fixture had unused remaining expected cmds:\n{remaining}"
+        )

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1,74 +1,8 @@
 import argparse
-import subprocess
-from collections import deque
 
 import pytest
 
 from opensafely import pull
-
-
-_actual_run = subprocess.run
-
-
-class SubprocessRunFixture(deque):
-    """Fixture for mocking subprocess.run.
-
-    Add expected calls and their responses to subprocess.run:
-
-        run.expect(['your', 'cmd', 'here'], returncode=1, stderr='error!')
-
-    And when subprocess.run is called with that command, it will return the
-    appropriate CompletedProcess object.
-
-    If your code is calling subprocess.run with check=True, pass that to the
-    expect() call too, and a CalledProcessError will be raised if the
-    returncode is not 0.
-
-        run.expect(['your', 'cmd', 'here'], check=True, returncode=1, stderr='error!')
-
-    By default, strict=True, which means all calls to subprocess.run must have
-    a matching expect(), or an AssertionError will be raised.
-
-    If strict is set to False, any unexpected calls are passed through to the
-    real subprocess.run(). This allows you to only mock some calls to
-    subprocess.run().
-    """
-
-    strict = True
-
-    def expect(self, cmd, returncode=0, stdout=None, stderr=None, check=False):
-        if check and returncode != 0:
-            value = subprocess.CalledProcessError(returncode, cmd, stdout, stderr)
-        else:
-            value = subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
-        self.append((cmd, value))
-
-    def run(self, cmd, *args, **kwargs):
-        """The replacement run() function."""
-        expected, value = self.popleft()
-
-        if expected == cmd:
-            if isinstance(value, Exception):
-                raise value
-            return value
-
-        if self.strict:
-            raise AssertionError(f"run fixture got unexpected call: {cmd}")
-        else:
-            # pass through to system
-            return _actual_run(cmd, *args, **kwargs)
-
-
-@pytest.fixture
-def run(monkeypatch):
-    fixture = SubprocessRunFixture()
-    monkeypatch.setattr(subprocess, "run", fixture.run)
-    yield fixture
-    if len(fixture) != 0:
-        remaining = "\n".join(str(cmd) for cmd, _ in fixture)
-        raise AssertionError(
-            f"run fixture had unused remaining expected cmds:\n{remaining}"
-        )
 
 
 def tag(image):

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -18,7 +18,9 @@ mocker._original_send = requests.Session.send
 
 @pytest.fixture(autouse=True)
 def clean_cache_file():
-    upgrade.CACHE_FILE.unlink(missing_ok=True)
+    if upgrade.CACHE_FILE.exists():
+        upgrade.CACHE_FILE.unlink()
+
 
 
 @pytest.fixture

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -1,0 +1,143 @@
+import argparse
+from datetime import datetime, timedelta
+import os
+
+import pytest
+
+import opensafely
+from opensafely import upgrade
+
+from requests_mock import mocker
+from opensafely._vendor import requests
+
+# Because we're using a vendored version of requests we need to monkeypatch the
+# requests_mock library so it references our vendored library instead
+mocker.requests = requests
+mocker._original_send = requests.Session.send
+
+
+@pytest.fixture(autouse=True)
+def clean_cache_file():
+    upgrade.CACHE_FILE.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def set_current_version(monkeypatch):
+    def set(value):
+        assert value[0] == "v", "Current __version__ must start with v"
+        monkeypatch.setattr(opensafely, "__version__", value)
+
+    yield set
+
+
+def test_main_latest_upgrade(requests_mock, run, set_current_version):
+    requests_mock.get(
+        "https://pypi.org/pypi/opensafely/json",
+        json={"info": {"version": "1.1.0"}},
+    )
+    set_current_version("v1.0.0")
+    run.expect(["pip", "install", "--upgrade", "opensafely==1.1.0"])
+    upgrade.main("latest")
+
+
+def test_main_latest_no_upgrade(requests_mock, run, set_current_version, capsys):
+    requests_mock.get(
+        "https://pypi.org/pypi/opensafely/json",
+        json={"info": {"version": "1.0.0"}},
+    )
+    set_current_version("v1.0.0")
+    upgrade.main("latest")
+    out, err = capsys.readouterr()
+    assert out.strip() == "opensafely is already at version 1.0.0"
+
+
+def test_main_specifi_no_upgrade(run, set_current_version, capsys):
+    set_current_version("v1.1.0")
+    upgrade.main("1.1.0")
+    out, err = capsys.readouterr()
+    assert out.strip() == "opensafely is already at version 1.1.0"
+
+
+def test_get_latest_version_no_cache(requests_mock):
+    requests_mock.get(
+        "https://pypi.org/pypi/opensafely/json",
+        json={"info": {"version": "1.1.0"}},
+    )
+
+    assert not upgrade.CACHE_FILE.exists()
+    assert upgrade.get_latest_version() == "1.1.0"
+    assert upgrade.CACHE_FILE.read_text() == "1.1.0"
+
+
+def test_get_latest_version_with_cache(requests_mock):
+    requests_mock.get(
+        "https://pypi.org/pypi/opensafely/json",
+        json={"info": {"version": "1.1.0"}},
+    )
+    upgrade.CACHE_FILE.write_text("1.0.0")
+    assert upgrade.get_latest_version() == "1.0.0"
+    assert upgrade.get_latest_version(force=True) == "1.1.0"
+
+
+def test_get_latest_version_cache_expired(requests_mock):
+    requests_mock.get(
+        "https://pypi.org/pypi/opensafely/json",
+        json={"info": {"version": "1.1.0"}},
+    )
+    upgrade.CACHE_FILE.write_text("1.0.0")
+    # set mtime to 1 day ago
+    a_day_ago = (datetime.utcnow() - timedelta(days=1)).timestamp()
+    os.utime(upgrade.CACHE_FILE, (a_day_ago, a_day_ago))
+
+    # ignores cache and uses the newer latest version from requests
+    # check cache updated
+    assert upgrade.get_latest_version() == "1.1.0"
+    assert upgrade.CACHE_FILE.read_text() == "1.1.0"
+
+
+def test_need_to_update(set_current_version):
+    set_current_version("v1.0.0")
+    assert upgrade.need_to_update("1.1.0")
+    set_current_version("v1.1.0")
+    assert not upgrade.need_to_update("1.1.0")
+    assert not upgrade.need_to_update("1.0.0")
+    # check version comparision is not lexographical
+    set_current_version("v1.11.0")
+    assert not upgrade.need_to_update("1.2.0")
+    set_current_version("v1.2.0")
+    assert upgrade.need_to_update("1.11.0")
+
+
+def test_check_version_needs_updating(set_current_version, capsys):
+    upgrade.CACHE_FILE.write_text("1.1.0")
+    set_current_version("v1.0.0")
+    assert upgrade.check_version()
+    out, _ = capsys.readouterr()
+    assert out.strip() == (
+        f"Warning: there is a newer version of opensafely available - please run 'opensafely upgrade' to update to 1.1.0"
+    )
+
+
+def test_check_version_needs_updating(set_current_version, capsys):
+    upgrade.CACHE_FILE.write_text("1.0.0")
+    set_current_version("v1.0.0")
+    assert not upgrade.check_version()
+    out, _ = capsys.readouterr()
+    assert out.strip() == ""
+
+
+@pytest.mark.parametrize(
+    "argv,expected",
+    [
+        ([], argparse.Namespace(version="latest")),
+        (["1.0.0"], argparse.Namespace(version="1.0.0")),
+    ],
+)
+def test_pull_parser_valid(argv, expected, capsys):
+    parser = argparse.ArgumentParser()
+    upgrade.add_arguments(parser)
+    if isinstance(expected, SystemExit):
+        with pytest.raises(SystemExit):
+            parser.parse_args(argv)
+    else:
+        assert parser.parse_args(argv) == expected


### PR DESCRIPTION
This is just a helpful wrapper around running pip upgrade step, but its
more user friendly

Additionally, we nag user to run the new upgrade command if we detect
a more recent of opensafely is available. Not quite auto-update, but
might get us quite far as is.

Note: we cache the latest version for 2 hours, to avoid spamming pypi on
every command.