### PR TITLE
fix: use jobrunner to supply list of images

### DIFF
--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -1,13 +1,16 @@
 import subprocess
 import sys
 
+from opensafely._vendor.jobrunner import config
+
 
 DESCRIPTION = (
     "Command for updating the docker images used to run OpenSAFELY studies locally"
 )
-REGISTRY = "ghcr.io/opensafely-core"
-IMAGES = ["r", "python", "jupyter", "stata-mp"]
+REGISTRY = config.DOCKER_REGISTRY
+IMAGES = list(config.ALLOWED_IMAGES)
 DEPRECATED_REGISTRIES = ["docker.opensafely.org", "ghcr.io/opensafely"]
+IMAGES.sort()  # this is just for consistency for testing
 
 
 def add_arguments(parser):
@@ -59,9 +62,10 @@ def get_local_images():
     ps = subprocess.run(
         ["docker", "image", "ls", "--format={{.Repository}}"],
         check=True,
+        text=True,
         capture_output=True,
     )
-    lines = [line for line in ps.stdout.decode("utf8").split("\n") if line.strip()]
+    lines = [line for line in ps.stdout.splitlines() if line.strip()]
     return set(lines)
 
 

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -11,7 +11,7 @@ def tag(image):
 
 def test_default_no_local_images(run, capsys):
 
-    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout=b"")
+    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout="")
 
     pull.main(image="all", force=False)
     out, err = capsys.readouterr()
@@ -21,10 +21,11 @@ def test_default_no_local_images(run, capsys):
 
 def test_default_no_local_images_force(run, capsys):
 
-    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout=b"")
-    run.expect(["docker", "pull", tag("r")])
-    run.expect(["docker", "pull", tag("python")])
+    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout="")
+    run.expect(["docker", "pull", tag("cohortextractor")])
     run.expect(["docker", "pull", tag("jupyter")])
+    run.expect(["docker", "pull", tag("python")])
+    run.expect(["docker", "pull", tag("r")])
     run.expect(["docker", "pull", tag("stata-mp")])
     run.expect(["docker", "image", "prune", "--force"])
 
@@ -32,9 +33,10 @@ def test_default_no_local_images_force(run, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out.splitlines() == [
-        "Updating OpenSAFELY r image",
-        "Updating OpenSAFELY python image",
+        "Updating OpenSAFELY cohortextractor image",
         "Updating OpenSAFELY jupyter image",
+        "Updating OpenSAFELY python image",
+        "Updating OpenSAFELY r image",
         "Updating OpenSAFELY stata-mp image",
         "Cleaning up old images",
     ]
@@ -44,7 +46,7 @@ def test_default_with_local_images(run, capsys):
 
     run.expect(
         ["docker", "image", "ls", "--format={{.Repository}}"],
-        stdout=b"ghcr.io/opensafely-core/r",
+        stdout="ghcr.io/opensafely-core/r",
     )
     run.expect(["docker", "pull", tag("r")])
     run.expect(["docker", "image", "prune", "--force"])
@@ -60,7 +62,7 @@ def test_default_with_local_images(run, capsys):
 
 def test_specific_image(run, capsys):
 
-    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout=b"")
+    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout="")
     run.expect(["docker", "pull", tag("r")])
     run.expect(["docker", "image", "prune", "--force"])
 

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -22,7 +22,6 @@ def clean_cache_file():
         upgrade.CACHE_FILE.unlink()
 
 
-
 @pytest.fixture
 def set_current_version(monkeypatch):
     def set(value):


### PR DESCRIPTION
 - keeps the cli in sync with jobrunner
 - added cohortextractor image as a consequence
 - use text=True in subprocess.run() for better x-platform parsing
 - refactored RunFixture to enforce check and text kwarg behaviour