### PR TITLE
fix: Pass `codelists check` if no codelists dir exists

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -91,6 +91,9 @@ def update(codelists_dir=None):
 
 def check():
     codelists_dir = Path.cwd() / CODELISTS_DIR
+    if not codelists_dir.exists():
+        print(f"No '{CODELISTS_DIR}' directory present so nothing to check")
+        return True
     codelists = parse_codelist_file(codelists_dir)
     manifest_file = codelists_dir / MANIFEST_FILE
     if not manifest_file.exists():

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -78,3 +78,8 @@ def test_codelists_check_fail_if_file_modified(codelists_path):
     os.chdir(codelists_path)
     with pytest.raises(SystemExit):
         codelists.check()
+
+
+def test_codelists_check_passes_if_no_codelists_dir(tmp_path):
+    os.chdir(tmp_path)
+    assert codelists.check()


### PR DESCRIPTION
We already implement this behaviour in our [test runner][1] but if this
really is the behaviour we want then its better to implement that here
and take the conditional out of the test runner.

[1]: https://github.com/opensafely-core/research-action/blob/30396ad13063b98d5573814448d6750e9bed823d/entrypoint.py#L46-L49