### PR TITLE
feat: add --preseed option to pull command

### DIFF
--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -32,18 +32,18 @@ def add_arguments(parser):
         help="Update docker images even if not present locally",
     )
     parser.add_argument(
-        "--preseed",
+        "--project",
         help="Use this project to yaml to decide which images to download",
     )
 
 
-def main(image="all", force=False, preseed=None):
+def main(image="all", force=False, project=None):
     if not docker_preflight_check():
         return False
 
-    if preseed:
+    if project:
         force = True
-        images = get_actions_from_project_file(preseed)
+        images = get_actions_from_project_file(project)
     elif image == "all":
         images = IMAGES
     else:
@@ -75,13 +75,13 @@ def main(image="all", force=False, preseed=None):
 def get_actions_from_project_file(project_yaml):
     path = Path(project_yaml)
     if not path.exists():
-        raise RuntimeError(f"Could not find {project_yaml} for preseed")
+        raise RuntimeError(f"Could not find {project_yaml}")
 
     try:
         with path.open() as f:
             project = YAML(typ="safe", pure=True).load(path)
     except (YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning) as e:
-        raise RuntimeError(f"Could not parse {project_yaml} for preseed: str(e)")
+        raise RuntimeError(f"Could not parse {project_yaml}: str(e)")
 
     images = []
     for action_name, action in project.get("actions", {}).items():
@@ -96,7 +96,7 @@ def get_actions_from_project_file(project_yaml):
             images.append(name)
 
     if not images:
-        raise RuntimeError(f"No actions found in {project_yaml} to preseed")
+        raise RuntimeError(f"No actions found in {project_yaml}")
 
     return images
 

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -1,8 +1,11 @@
+from pathlib import Path
 import subprocess
 import sys
 
 from opensafely._vendor.jobrunner import config
 from opensafely._vendor.jobrunner.local_run import docker_preflight_check
+from opensafely._vendor.ruamel.yaml import YAML
+from opensafely._vendor.ruamel.yaml.error import YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning
 
 
 DESCRIPTION = (
@@ -28,13 +31,20 @@ def add_arguments(parser):
         action="store_true",
         help="Update docker images even if not present locally",
     )
+    parser.add_argument(
+        "--preseed",
+        help="Use this project to yaml to decide which images to download",
+    )
 
 
-def main(image, force):
+def main(image="all", force=False, preseed=None):
     if not docker_preflight_check():
         return False
 
-    if image == "all":
+    if preseed:
+        force = True
+        images = get_actions_from_project_file(preseed)
+    elif image == "all":
         images = IMAGES
     else:
         # if user has requested a specific image, pull it regardless
@@ -60,6 +70,35 @@ def main(image, force):
 
     except subprocess.CalledProcessError as exc:
         sys.exit(exc.stderr)
+
+
+def get_actions_from_project_file(project_yaml):
+    path = Path(project_yaml)
+    if not path.exists():
+        raise RuntimeError(f"Could not find {project_yaml} for preseed")
+
+    try:
+        with path.open() as f:
+            project = YAML(typ="safe", pure=True).load(path)
+    except (YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning) as e:
+        raise RuntimeError(f"Could not parse {project_yaml} for preseed: str(e)")
+
+    images = []
+    for action_name, action in project.get("actions", {}).items():
+        if not action:
+            continue
+        command = action.get("run", None)
+        if command is None:
+            continue
+
+        name, _, version = command.partition(":")
+        if name in IMAGES:
+            images.append(name)
+
+    if not images:
+        raise RuntimeError(f"No actions found in {project_yaml} to preseed")
+
+    return images
 
 
 def get_local_images():

--- a/tests/fixtures/projects/bad.yaml
+++ b/tests/fixtures/projects/bad.yaml
@@ -1,0 +1,6 @@
+dashboard "Variables example":
+  - h1 text: Variables Example
+  -       dropdown my_var=pie:
+    - {"value": pie, "text": "Pie chart"}
+    - {"value": bar, "text": "Bar chart"}
+   p text: "Selected chart type: ${my_var}"

--- a/tests/fixtures/projects/noactions.yaml
+++ b/tests/fixtures/projects/noactions.yaml
@@ -1,0 +1,8 @@
+version: '3.0'
+
+expectations:
+  population_size: 1000
+
+actions:
+
+  generate_study_population:

--- a/tests/fixtures/projects/project.yaml
+++ b/tests/fixtures/projects/project.yaml
@@ -1,0 +1,21 @@
+version: '3.0'
+
+expectations:
+  population_size: 1000
+
+actions:
+  cohortextractor:
+    run: cohortextractor:latest generate_cohort --study-definition study_definition
+    outputs:
+      highly_sensitive:
+        cohort: output/a.csv
+  python:
+    run: python:latest python
+    outputs:
+      highly_sensitive:
+        cohort: output/b.csv
+  jupyter:
+    run: jupyter:latest python
+    outputs:
+      highly_sensitive:
+        cohort: output/c.csv

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -1,8 +1,12 @@
 import argparse
+from pathlib import Path
 
 import pytest
 
 from opensafely import pull
+
+
+project_fixture_path = Path(__file__).parent / "fixtures" / "projects"
 
 
 def tag(image):
@@ -79,6 +83,27 @@ def test_specific_image(run, capsys):
     ]
 
 
+
+def test_preseed(run, capsys):
+
+    run.expect(["docker", "info"])
+    run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout="")
+    run.expect(["docker", "pull", tag("cohortextractor")])
+    run.expect(["docker", "pull", tag("python")])
+    run.expect(["docker", "pull", tag("jupyter")])
+    run.expect(["docker", "image", "prune", "--force"])
+
+    pull.main(preseed=project_fixture_path / "project.yaml")
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert out.splitlines() == [
+        "Updating OpenSAFELY cohortextractor image",
+        "Updating OpenSAFELY python image",
+        "Updating OpenSAFELY jupyter image",
+        "Cleaning up old images",
+    ]
+
+
 def test_remove_deprecated_images(run):
     local_images = set(
         [
@@ -94,13 +119,29 @@ def test_remove_deprecated_images(run):
     pull.remove_deprecated_images(local_images)
 
 
+@pytest.mark.parametrize("project_yaml,exc_msg", [
+    ("doesnotexist.yaml", "Could not find"),
+    ("bad.yaml", "Could not parse"),
+    ("noactions.yaml", "No actions found"),
+])
+def test_get_actions_from_project_yaml_errors(project_yaml, exc_msg):
+    path = project_fixture_path / project_yaml
+    with pytest.raises(RuntimeError) as exc_info:
+        pull.get_actions_from_project_file(path)
+
+    str_exc = str(exc_info.value).lower()
+    assert exc_msg.lower() in str_exc
+    assert str(path).lower() in str_exc
+
+
 @pytest.mark.parametrize(
     "argv,expected",
     [
-        ([], argparse.Namespace(image="all", force=False)),
-        (["--force"], argparse.Namespace(image="all", force=True)),
-        (["r"], argparse.Namespace(image="r", force=False)),
-        (["r", "--force"], argparse.Namespace(image="r", force=True)),
+        ([], argparse.Namespace(image="all", force=False, preseed=None)),
+        (["--force"], argparse.Namespace(image="all", force=True, preseed=None)),
+        (["r"], argparse.Namespace(image="r", force=False, preseed=None)),
+        (["r", "--force"], argparse.Namespace(image="r", force=True, preseed=None)),
+        (["--preseed", "project.yaml"], argparse.Namespace(image="all", force=False, preseed="project.yaml")),
         (["invalid"], SystemExit()),
     ],
 )

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -84,7 +84,7 @@ def test_specific_image(run, capsys):
 
 
 
-def test_preseed(run, capsys):
+def test_project(run, capsys):
 
     run.expect(["docker", "info"])
     run.expect(["docker", "image", "ls", "--format={{.Repository}}"], stdout="")
@@ -93,7 +93,7 @@ def test_preseed(run, capsys):
     run.expect(["docker", "pull", tag("jupyter")])
     run.expect(["docker", "image", "prune", "--force"])
 
-    pull.main(preseed=project_fixture_path / "project.yaml")
+    pull.main(project=project_fixture_path / "project.yaml")
     out, err = capsys.readouterr()
     assert err == ""
     assert out.splitlines() == [
@@ -137,11 +137,11 @@ def test_get_actions_from_project_yaml_errors(project_yaml, exc_msg):
 @pytest.mark.parametrize(
     "argv,expected",
     [
-        ([], argparse.Namespace(image="all", force=False, preseed=None)),
-        (["--force"], argparse.Namespace(image="all", force=True, preseed=None)),
-        (["r"], argparse.Namespace(image="r", force=False, preseed=None)),
-        (["r", "--force"], argparse.Namespace(image="r", force=True, preseed=None)),
-        (["--preseed", "project.yaml"], argparse.Namespace(image="all", force=False, preseed="project.yaml")),
+        ([], argparse.Namespace(image="all", force=False, project=None)),
+        (["--force"], argparse.Namespace(image="all", force=True, project=None)),
+        (["r"], argparse.Namespace(image="r", force=False, project=None)),
+        (["r", "--force"], argparse.Namespace(image="r", force=True, project=None)),
+        (["--project", "project.yaml"], argparse.Namespace(image="all", force=False, project="project.yaml")),
         (["invalid"], SystemExit()),
     ],
 )


### PR DESCRIPTION
This will take a path to a project.yaml file, and use that to inform the
tool as to which images should be pulled locally.

The primary motivation for this is faster setup of development
environments, particularly with gitpod.io in mind.