### PR TITLE
test: Test with Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -45,7 +45,7 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
-pytest==6.1.2
+pytest==6.2.5
     # via -r requirements.dev.in
 regex==2020.11.13
     # via black

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -4,13 +4,11 @@
 #
 #    pip-compile requirements.dev.in
 #
-appdirs==1.4.4
-    # via black
 attrs==20.3.0
     # via
     #   jsonschema
     #   pytest
-black==20.8b1
+black==21.10b0
     # via -r requirements.dev.in
 certifi==2020.11.8
     # via requests
@@ -33,10 +31,12 @@ packaging==20.7
     # via
     #   pytest
     #   vendoring
-pathspec==0.8.1
+pathspec==0.9.0
     # via black
 pip-tools==5.4.0
     # via -r requirements.dev.in
+platformdirs==2.4.0
+    # via black
 pluggy==0.13.1
     # via pytest
 py==1.10.0
@@ -49,12 +49,12 @@ pytest==6.1.2
     # via -r requirements.dev.in
 regex==2020.11.13
     # via black
-requests-mock==1.8.0
-    # via -r requirements.dev.in
 requests==2.25.0
     # via
     #   requests-mock
     #   vendoring
+requests-mock==1.8.0
+    # via -r requirements.dev.in
 six==1.15.0
     # via
     #   jsonschema
@@ -62,12 +62,11 @@ six==1.15.0
     #   requests-mock
 toml==0.10.2
     # via
-    #   black
     #   pytest
     #   vendoring
-typed-ast==1.4.1
+tomli==1.2.2
     # via black
-typing-extensions==3.7.4.3
+typing-extensions==3.10.0.2
     # via black
 urllib3==1.26.5
     # via requests


### PR DESCRIPTION
I was looking at https://github.com/opensafely/documentation/issues/485 and wondering what Python version someone might get if they install Python from Microsoft Store.

It's possible (though can't check) that soon-ish they'd get Python 3.10 when searching for Python.

So, it seems wise to run the tests with Python 3.10 here, because:

* the tests work (with a couple of dependency upgrades here)
* to flag any potential future issues that we might miss otherwise