### PR TITLE
chore: Update URLs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,8 @@ setup(
     python_requires=">=3.7",
     entry_points={"console_scripts": ["opensafely=opensafely:main"]},
     classifiers=["License :: OSI Approved :: GNU General Public License v3 (GPLv3)"],
+    project_urls={
+        "Homepage": "https://opensafely.org",
+        "Documentation": "https://docs.opensafely.org",
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     version=version,
     packages=find_namespace_packages(exclude=["tests"]),
     include_package_data=True,
-    url="https://github.com/opensafely/opensafely-cli",
+    url="https://github.com/opensafely-core/opensafely-cli",
     description="Command line tool for running OpenSAFELY studies locally.",
     license="GPLv3",
     author="OpenSAFELY",


### PR DESCRIPTION
GitHub redirects the previous URL. But it's still nice to be directly
correct.