### PR TITLE
fix: Strip trailing slash from codelist paths

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -170,7 +170,7 @@ def parse_codelist_file(codelists_dir):
         exit_with_error(f"No file found at '{CODELISTS_DIR}/{CODELISTS_FILE}'")
     codelists = []
     for line in codelists_file.read_text().splitlines():
-        line = line.strip()
+        line = line.strip().rstrip("/")
         if not line or line.startswith("#"):
             continue
         tokens = line.split("/")

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -5,7 +5,12 @@ import sys
 from opensafely._vendor.jobrunner import config
 from opensafely._vendor.jobrunner.cli.local_run import docker_preflight_check
 from opensafely._vendor.ruamel.yaml import YAML
-from opensafely._vendor.ruamel.yaml.error import YAMLError, YAMLStreamError, YAMLWarning, YAMLFutureWarning
+from opensafely._vendor.ruamel.yaml.error import (
+    YAMLError,
+    YAMLStreamError,
+    YAMLWarning,
+    YAMLFutureWarning,
+)
 
 
 DESCRIPTION = (

--- a/tests/fixtures/codelists/codelists.txt
+++ b/tests/fixtures/codelists/codelists.txt
@@ -1,3 +1,3 @@
 opensafely/covid-identification/2020-06-03
-opensafely/chronic-respiratory-disease/2020-04-10
+opensafely/chronic-respiratory-disease/2020-04-10/
 opensafely/current-asthma/2020-05-06

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -85,7 +85,6 @@ def test_specific_image(run, capsys):
     ]
 
 
-
 def test_project(run, capsys):
 
     run.expect(["docker", "info"])
@@ -121,11 +120,14 @@ def test_remove_deprecated_images(run):
     pull.remove_deprecated_images(local_images)
 
 
-@pytest.mark.parametrize("project_yaml,exc_msg", [
-    ("doesnotexist.yaml", "Could not find"),
-    ("bad.yaml", "Could not parse"),
-    ("noactions.yaml", "No actions found"),
-])
+@pytest.mark.parametrize(
+    "project_yaml,exc_msg",
+    [
+        ("doesnotexist.yaml", "Could not find"),
+        ("bad.yaml", "Could not parse"),
+        ("noactions.yaml", "No actions found"),
+    ],
+)
 def test_get_actions_from_project_yaml_errors(project_yaml, exc_msg):
     path = project_fixture_path / project_yaml
     with pytest.raises(RuntimeError) as exc_info:
@@ -143,7 +145,10 @@ def test_get_actions_from_project_yaml_errors(project_yaml, exc_msg):
         (["--force"], argparse.Namespace(image="all", force=True, project=None)),
         (["r"], argparse.Namespace(image="r", force=False, project=None)),
         (["r", "--force"], argparse.Namespace(image="r", force=True, project=None)),
-        (["--project", "project.yaml"], argparse.Namespace(image="all", force=False, project="project.yaml")),
+        (
+            ["--project", "project.yaml"],
+            argparse.Namespace(image="all", force=False, project="project.yaml"),
+        ),
         (["invalid"], SystemExit()),
     ],
 )


### PR DESCRIPTION
It's easy to include these and the error it produces is non-obvious.

Closes #57