### PR TITLE
fix: gracefully fail when git not installed

### DIFF
--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -100,18 +100,20 @@ def get_repository_name():
     if "GITHUB_REPOSITORY" in os.environ:
         return os.environ["GITHUB_REPOSITORY"]
     else:
-
-        url = subprocess.run(
-            args=["git", "config", "--get", "remote.origin.url"],
-            capture_output=True,
-            text=True,
-        ).stdout
-        return (
-            url.replace("https://github.com/", "")
-            .replace("git@github.com:", "")
-            .replace(".git", "")
-            .strip()
-        )
+        try:
+            url = subprocess.run(
+                args=["git", "config", "--get", "remote.origin.url"],
+                capture_output=True,
+                text=True,
+            ).stdout
+            return (
+                url.replace("https://github.com/", "")
+                .replace("git@github.com:", "")
+                .replace(".git", "")
+                .strip()
+            )
+        except FileNotFoundError:
+            return None
 
 
 def get_allowed_datasets(respository_name, permissions):


### PR DESCRIPTION
users may not have git installed, or available on path. In this case, don't throw error but instead proceed as if repo name is unavailable.