### PR TITLE
Switch to 3.8 as the base version

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -32,10 +32,10 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v1
-    - name: Set up Python 3.7
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.8
 
     - name: Install wheel package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
     runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,16 +1,5 @@
 # Developer docs
 
-**Note on Python versions:** We currently need to support Python 3.7 and
-up as, historically, some researchers had 3.7 easily available but not
-3.8. Further down the line we'll probably aim to ship our own
-self-contained executable so we'll be able to use whatever Python
-version we want.
-
-However, the [vendoring](https://pypi.org/project/vendoring/) tool (see
-below) needs 3.8+ so we have to use 3.8 for developing with. The tests
-run under 3.7 in CI which should guard against accidental 3.8isms
-creeping in.
-
 ## Vendoring
 
 To minimise the possibility for installation issues this package vendors

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This tool is part of the [OpenSAFELY](https://www.opensafely.org)
 project.
 
 To use it you will need to install:
- * [Python](https://www.python.org/downloads/) (at least version 3.7, but the more recent the better)
+ * [Python](https://www.python.org/downloads/) (at least version 3.8, but the more recent the better)
  * [git](https://git-scm.com/downloads)
  * [Docker](https://docs.docker.com/get-docker/)
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="GPLv3",
     author="OpenSAFELY",
     author_email="tech@opensafely.org",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={"console_scripts": ["opensafely=opensafely:main"]},
     classifiers=["License :: OSI Approved :: GNU General Public License v3 (GPLv3)"],
     project_urls={


### PR DESCRIPTION
This sets the minimum version of Python we support to 3.8.