### PR TITLE
fix: read git config instead of using git cli

### DIFF
--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -102,16 +102,19 @@ def get_repository_name():
         return os.environ["GITHUB_REPOSITORY"]
     else:
         git_config_path = Path(".git", "config")
+        if not git_config_path.is_file():
+            return
         config = configparser.ConfigParser()
         config.read(git_config_path)
-        if 'remote "origin"' in config.sections():
-            url = config['remote "origin"']["url"]
-            return (
-                url.replace("https://github.com/", "")
-                .replace("git@github.com:", "")
-                .replace(".git", "")
-                .strip()
-            )
+        if 'remote "origin"' not in config.sections():
+            return
+        url = config['remote "origin"']["url"]
+        return (
+            url.replace("https://github.com/", "")
+            .replace("git@github.com:", "")
+            .replace(".git", "")
+            .strip()
+        )
 
 
 def get_allowed_datasets(respository_name, permissions):

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -66,7 +66,10 @@ def format_function_call(func):
 def write_study_def(path, dataset):
     restricted = dataset.value
     for a in [1, 2]:
-        f = path / f"study_definition_{'' if restricted else 'un'}restricted_{a}.py"
+        f = (
+            path
+            / f"study_definition_{'' if restricted else 'un'}restricted_{a}.py"
+        )
         f.write_text(
             textwrap.dedent(
                 f"""\
@@ -98,7 +101,10 @@ def validate_pass(capsys, continue_on_error):
 def validate_fail(capsys, continue_on_error):
     def validate_fail_output(stdout, stderr):
         assert stdout != "Success\n"
-        assert "Usage of restricted datasets found:" in stderr or "git config" in stderr.lower()
+        assert (
+            "Usage of restricted datasets found:" in stderr
+            or "git config" in stderr.lower()
+        )
         if "Usage of restricted datasets found:" in stderr:
             assert "icnarc" in stderr
             assert "admitted_to_icu" in stderr
@@ -134,7 +140,9 @@ def repo_path(tmp_path):
 @pytest.mark.parametrize(
     "repo, protocol, dataset, continue_on_error",
     itertools.chain(
-        itertools.product(list(Repo), list(Protocol), list(Dataset), [True, False]),
+        itertools.product(
+            list(Repo), list(Protocol), list(Dataset), [True, False]
+        ),
         itertools.product([None], [None], list(Dataset), [True, False]),
     ),
 )
@@ -161,10 +169,14 @@ def test_check(
                 url = ""
             git_init(url)
 
-    if not repo or (dataset == Dataset.RESTRICTED and repo not in [
-        Repo.PERMITTED,
-        Repo.PERMITTED_MULTIPLE,
-    ]):
+    if not repo or (
+        dataset == Dataset.RESTRICTED
+        and repo
+        not in [
+            Repo.PERMITTED,
+            Repo.PERMITTED_MULTIPLE,
+        ]
+    ):
         validate_fail(capsys, continue_on_error)
     else:
         validate_pass(capsys, continue_on_error)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -101,21 +101,17 @@ def validate_pass(capsys, continue_on_error):
 def validate_fail(capsys, continue_on_error):
     def validate_fail_output(stdout, stderr):
         assert stdout != "Success\n"
-        assert (
-            "Usage of restricted datasets found:" in stderr
-            or "git config" in stderr.lower()
-        )
-        if "Usage of restricted datasets found:" in stderr:
-            assert "icnarc" in stderr
-            assert "admitted_to_icu" in stderr
-            assert "3:" in stderr
-            assert "4:" not in stderr
-            assert "5:" not in stderr
-            assert "#b=" not in stderr
-            assert "#d=" not in stderr
-            assert "unrestricted" not in stderr
-            assert "study_definition_restricted_1.py" in stderr
-            assert "study_definition_restricted_2.py" in stderr
+        assert "Usage of restricted datasets found:" in stderr
+        assert "icnarc" in stderr
+        assert "admitted_to_icu" in stderr
+        assert "3:" in stderr
+        assert "4:" not in stderr
+        assert "5:" not in stderr
+        assert "#b=" not in stderr
+        assert "#d=" not in stderr
+        assert "unrestricted" not in stderr
+        assert "study_definition_restricted_1.py" in stderr
+        assert "study_definition_restricted_2.py" in stderr
 
     if not continue_on_error:
         with pytest.raises(SystemExit):
@@ -127,6 +123,20 @@ def validate_fail(capsys, continue_on_error):
         check.main(continue_on_error)
         stdout, stderr = capsys.readouterr()
         validate_fail_output(stdout, stdout)
+
+
+def validate_norepo(capsys, continue_on_error):
+    if not continue_on_error:
+        with pytest.raises(SystemExit):
+            check.main(continue_on_error)
+            stdout, stderr = capsys.readouterr()
+            assert "git config" in stdout.lower()
+            assert "Unable to find repository name" in stderr
+    else:
+        check.main(continue_on_error)
+        stdout, stderr = capsys.readouterr()
+        assert stderr == ""
+        assert stdout == ""
 
 
 @pytest.fixture
@@ -169,14 +179,12 @@ def test_check(
                 url = ""
             git_init(url)
 
-    if not repo or (
-        dataset == Dataset.RESTRICTED
-        and repo
-        not in [
-            Repo.PERMITTED,
-            Repo.PERMITTED_MULTIPLE,
-        ]
-    ):
+    if not repo and dataset != Dataset.RESTRICTED:
+        validate_norepo(capsys, continue_on_error)
+    elif dataset == Dataset.RESTRICTED and repo not in [
+        Repo.PERMITTED,
+        Repo.PERMITTED_MULTIPLE,
+    ]:
         validate_fail(capsys, continue_on_error)
     else:
         validate_pass(capsys, continue_on_error)

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -98,17 +98,18 @@ def validate_pass(capsys, continue_on_error):
 def validate_fail(capsys, continue_on_error):
     def validate_fail_output(stdout, stderr):
         assert stdout != "Success\n"
-        assert "Usage of restricted datasets found:" in stderr
-        assert "icnarc" in stderr
-        assert "admitted_to_icu" in stderr
-        assert "3:" in stderr
-        assert "4:" not in stderr
-        assert "5:" not in stderr
-        assert "#b=" not in stderr
-        assert "#d=" not in stderr
-        assert "unrestricted" not in stderr
-        assert "study_definition_restricted_1.py" in stderr
-        assert "study_definition_restricted_2.py" in stderr
+        assert "Usage of restricted datasets found:" in stderr or "git config" in stderr.lower()
+        if "Usage of restricted datasets found:" in stderr:
+            assert "icnarc" in stderr
+            assert "admitted_to_icu" in stderr
+            assert "3:" in stderr
+            assert "4:" not in stderr
+            assert "5:" not in stderr
+            assert "#b=" not in stderr
+            assert "#d=" not in stderr
+            assert "unrestricted" not in stderr
+            assert "study_definition_restricted_1.py" in stderr
+            assert "study_definition_restricted_2.py" in stderr
 
     if not continue_on_error:
         with pytest.raises(SystemExit):
@@ -160,10 +161,10 @@ def test_check(
                 url = ""
             git_init(url)
 
-    if dataset == Dataset.RESTRICTED and repo not in [
+    if not repo or (dataset == Dataset.RESTRICTED and repo not in [
         Repo.PERMITTED,
         Repo.PERMITTED_MULTIPLE,
-    ]:
+    ]):
         validate_fail(capsys, continue_on_error)
     else:
         validate_pass(capsys, continue_on_error)


### PR DESCRIPTION
Github desktop is the recommended installation of git as per the opensafely docs.
It does not add `git` to the Windows path. Therefore when `opensafely check` tries to call git to ascertain the repository name, this can fail.

This PR parses the git config file instead.