### PR TITLE
feat: prompt to update when docker images out of date

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -47,7 +47,16 @@ def main():
     # there's some hint as to why their invocation is failing before being told
     # by argparse.
     if len(sys.argv) == 1 or sys.argv[1] != "upgrade":
-        upgrade.check_version()
+        try:
+            upgrade.check_version()
+        except Exception:
+            pass
+
+    if len(sys.argv) == 1 or sys.argv[1] != "pull":
+        try:
+            pull.check_version()
+        except Exception:
+            pass
 
     # start by using looser parsing only known args, so we can get the sub command
     args, unknown = parser.parse_known_args()

--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -93,14 +93,11 @@ def need_to_update(latest):
 
 
 def check_version():
-    try:
-        latest = get_latest_version()
-        update = need_to_update(latest)
-        if update:
-            print(
-                f"Warning: there is a newer version of opensafely available ({latest}) - please upgrade by running:\n"
-                "    opensafely upgrade\n"
-            )
-        return update
-    except Exception:
-        pass  # this is an optional check, it should never stop the program
+    latest = get_latest_version()
+    update = need_to_update(latest)
+    if update:
+        print(
+            f"Warning: there is a newer version of opensafely available ({latest}) - please upgrade by running:\n"
+            "    opensafely upgrade\n"
+        )
+    return update


### PR DESCRIPTION
This is similar to how we prompt for the cli tool itself.

The docker registry API is horrible, and just looking up anything
requires an auth dance, even for public resources.
