### PR TITLE
Remove restrictions on therapeutics dataset

### DIFF
--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -11,7 +11,6 @@ DESCRIPTION = "Check the opensafely project for correctness"
 
 RESTRICTED_DATASETS = {
     "icnarc": ["admitted_to_icu"],
-    "therapeutics": ["with_covid_therapeutics"],  
     "isaric": ["with_an_isaric_record"]  
 }
 

--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -4,7 +4,5 @@ opensafely/immunosuppressant-meds-research:
   allow: ['icnarc']
 opensafely/school-age-children-and-covid:
   allow: ['icnarc']
-opensafely/antibody-and-antiviral-deployment:
-  allow: ['therapeutics']
 opensafely/hdruk-os-covid-paeds:
   allow: ['isaric']

--- a/tests/fixtures/permissions/repository_permissions.yaml
+++ b/tests/fixtures/permissions/repository_permissions.yaml
@@ -4,9 +4,7 @@ opensafely/dummy_ons:
   allow: ['ons']
 opensafely/dummy_icnarc_ons:
   allow: ['icnarc','ons']
-opensafely/dummy_therapeutics:
-    allow: ['therapeutics']
 opensafely/dummy_isaric:
     allow: ['isaric']
 opensafely/dummy_all:
-  allow: ['icnarc','ons','therapeutics', 'isaric']
+  allow: ['icnarc','ons', 'isaric']

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -25,18 +25,15 @@ opensafely/dummy_ons:
     allow: ['ons']
 opensafely/dummy_icnarc_ons:
     allow: ['icnarc','ons']
-opensafely/dummy_therapeutics:
-    allow: ['therapeutics']
 opensafely/dummy_isaric:
     allow: ['isaric']
 opensafely/dummy_all:
-    allow: ['icnarc','ons','therapeutics', 'isaric]
+    allow: ['icnarc','ons', 'isaric]
 """
 
 
 class Repo(Enum):
     PERMITTED_ICNARC = "opensafely/dummy_icnarc"
-    PERMITTED_THERAPEUTICS = "opensafely/dummy_therapeutics"
     PERMITTED_ISARIC = "opensafely/dummy_isaric"
     PERMITTED_MULTIPLE = "opensafely/dummy_icnarc_ons"
     PERMITTED_ALL = "opensafely/dummy_all"
@@ -60,7 +57,7 @@ study = StudyDefinition ("""
 
 
 UNRESTRICTED_FUNCTION = "with_these_medications"
-RESTRICTED_FUNCTIONS = ["admitted_to_icu", "with_covid_therapeutics", "with_an_isaric_record"]
+RESTRICTED_FUNCTIONS = ["admitted_to_icu", "with_an_isaric_record"]
 
 
 def format_function_call(func):
@@ -87,8 +84,6 @@ def write_study_def(path, dataset):
                 #b={format_function_call(RESTRICTED_FUNCTIONS[0])},
                 c={format_function_call(RESTRICTED_FUNCTIONS[1])+',' if restricted else ''},
                 #d={format_function_call(RESTRICTED_FUNCTIONS[1])},
-                e={format_function_call(RESTRICTED_FUNCTIONS[2])+',' if restricted else ''},
-                #f={format_function_call(RESTRICTED_FUNCTIONS[2])},
                 y={format_function_call(UNRESTRICTED_FUNCTION)},
                 #z={format_function_call(UNRESTRICTED_FUNCTION)},
                 )"""
@@ -206,13 +201,11 @@ def test_check(
         validate_norepo(capsys, continue_on_error)
     elif dataset == Dataset.RESTRICTED and repo != Repo.PERMITTED_ALL:
         icnarc = ("icnarc", "admitted_to_icu", "3")
-        theraputics = ("therapeutics", "with_covid_therapeutics", "5")
-        isaric = ("isaric", "with_an_isaric_record", "7")
+        isaric = ("isaric", "with_an_isaric_record", "5")
         
         permitted_mapping = {
             "permitted": {
                 Repo.PERMITTED_ICNARC: (icnarc,),
-                Repo.PERMITTED_THERAPEUTICS: (theraputics,),
                 Repo.PERMITTED_ISARIC: (isaric,),
                 Repo.PERMITTED_MULTIPLE: (icnarc,),
                 Repo.UNKNOWN: (),
@@ -220,13 +213,12 @@ def test_check(
                 None: (),
             },
             "not_permitted": {
-                Repo.PERMITTED_ICNARC: (theraputics, isaric),
-                Repo.PERMITTED_THERAPEUTICS: (icnarc, isaric),
-                Repo.PERMITTED_ISARIC: (icnarc, theraputics),
-                Repo.PERMITTED_MULTIPLE: (theraputics, isaric),
-                Repo.UNKNOWN: (icnarc, theraputics, isaric),
-                Repo.UNPERMITTED: (icnarc, theraputics, isaric),
-                None: (icnarc, theraputics, isaric),
+                Repo.PERMITTED_ICNARC: (isaric,),
+                Repo.PERMITTED_ISARIC: (icnarc,),
+                Repo.PERMITTED_MULTIPLE: (isaric,),
+                Repo.UNKNOWN: (icnarc, isaric),
+                Repo.UNPERMITTED: (icnarc, isaric),
+                None: (icnarc, isaric),
             }
         }
         validate_fail(


### PR DESCRIPTION
Amir has confirmed that there are no special restrictions on the therapeutics dataset so these warnings can be removed