### PR TITLE
Restrict ONS_CIS dataset

### DIFF
--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -11,7 +11,8 @@ DESCRIPTION = "Check the opensafely project for correctness"
 
 RESTRICTED_DATASETS = {
     "icnarc": ["admitted_to_icu"],
-    "isaric": ["with_an_isaric_record"]  
+    "isaric": ["with_an_isaric_record"],
+    "ons_cis": ["with_an_ons_cis_record"]  
 }
 
 PERMISSIONS_URL = "https://raw.githubusercontent.com/opensafely-core/opensafely-cli/main/repository_permissions.yaml"

--- a/tests/fixtures/permissions/repository_permissions.yaml
+++ b/tests/fixtures/permissions/repository_permissions.yaml
@@ -2,9 +2,11 @@ opensafely/dummy_icnarc:
   allow: ['icnarc']
 opensafely/dummy_ons:
   allow: ['ons']
+opensafely/dummy_ons_cis:
+  allow: ['ons_cis']  
 opensafely/dummy_icnarc_ons:
-  allow: ['icnarc','ons']
+  allow: ['icnarc', 'ons', 'ons_cis']
 opensafely/dummy_isaric:
-    allow: ['isaric']
+  allow: ['isaric']
 opensafely/dummy_all:
-  allow: ['icnarc','ons', 'isaric']
+  allow: ['icnarc', 'ons', 'isaric', 'ons_cis']


### PR DESCRIPTION
Restricts use of the ONS_CIS dataset.  Currently this means no studies can use it, until allowed studies are confirmed, and repos added to `repository_permissions.yaml`