### PR TITLE
Use cross-platform sed invocation

### DIFF
--- a/scripts/update-all-dependencies.sh
+++ b/scripts/update-all-dependencies.sh
@@ -12,7 +12,8 @@ pip-compile "$@" vendor.in
 # We can't (and don't want to) vendor this binary package but I can't find a
 # way to prevent pip-tools from including it so we excise it here.
 echo "Removing ruamel.yaml.clib dependency"
-sed -i 's/^\(ruamel\.yaml\.clib\)/# \1/' vendor.txt
+sed -i.bak -e 's/^\(ruamel[.-]yaml[.-]clib\)/# \1/' vendor.txt
+rm -f vendor.txt.bak
 
 echo "Vendoring all dependencies"
 vendoring sync -v


### PR DESCRIPTION
macOS ships with BSD sed so we need to support both BSD and GNU
versions.