### PR TITLE
Adding relevant permissions for ONS team to access the ONS-CIS dataset

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -8,3 +8,5 @@ opensafely/hdruk-os-covid-paeds:
   allow: ['isaric']
 opensafely/renal-short-data-report:
   allow: ['ukrr']
+opensafely/MH_pandemic:
+  allow: ['ons_cis']


### PR DESCRIPTION
Update to `repository_permissions.yaml` to allow the ONS-CIS Mental Health project access to the ONS-CIS dataset.