### PR TITLE
add ckd coverage repo to ukrr allowed list

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -10,5 +10,7 @@ opensafely/renal-short-data-report:
   allow: ['ukrr']
 opensafely/ckd-coverage-ve:
   allow: ['ukrr']
+opensafely/sotrovimab-and-molnupiravir:
+  allow: ['ukrr']
 opensafely/MH_pandemic:
   allow: ['ons_cis']

--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -8,5 +8,7 @@ opensafely/hdruk-os-covid-paeds:
   allow: ['isaric']
 opensafely/renal-short-data-report:
   allow: ['ukrr']
+opensafely/ckd-coverage-ve:
+  allow: ['ukrr']
 opensafely/MH_pandemic:
   allow: ['ons_cis']


### PR DESCRIPTION
This adds [this repo](https://github.com/opensafely/ckd-coverage-ve/tree/main/analysis) to the list of repos allowed to use the UKRR variables.

This repo is linked to projects [88](https://www.opensafely.org/approved-projects/#project-88) and [110](https://www.opensafely.org/approved-projects/#project-110), approved to use the UKRR variables