### PR TITLE
Add `opensafely exec` command

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -9,7 +9,7 @@ opensafely_module_dir = Path(__file__).parent
 pkg_resources.working_set.add_entry(f"{opensafely_module_dir}/_vendor")
 
 from opensafely import (
-    check, codelists, extract_stats, jupyter, pull, unzip, upgrade, info 
+    check, codelists, execute, extract_stats, jupyter, pull, unzip, upgrade, info
 )
 from opensafely._vendor.jobrunner.cli import local_run
 
@@ -52,6 +52,7 @@ def main():
     add_subcommand("unzip", unzip)
     add_subcommand("extract-stats", extract_stats)
     add_subcommand("info", info)
+    add_subcommand("exec", execute)
 
     # we version check before parse_args is called so that if a user is
     # following recent documentation but has an old opensafely installed,

--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -1,0 +1,56 @@
+import argparse
+import os
+import pathlib
+import subprocess
+
+from opensafely._vendor.jobrunner import config
+from opensafely._vendor.jobrunner.cli.local_run import docker_preflight_check
+
+DESCRIPTION = "Run an OpenSAFELY action outside of the `project.yaml` pipeline"
+
+
+def add_arguments(parser):
+    parser.add_argument(
+        "image",
+        metavar="IMAGE_NAME:VERSION",
+        help="OpenSAFELY image and version (e.g. databuilder:v1)",
+    )
+    parser.add_argument(
+        "docker_args",
+        nargs=argparse.REMAINDER,
+        metavar="...",
+        help="Any additional arguments to pass to the image",
+    )
+    return parser
+
+
+def main(image, docker_args):
+    if not docker_preflight_check():
+        return False
+
+    try:
+        # In order for any files that get created to have the appropriate owner/group we
+        # run the command using the current user's UID/GID
+        uid = os.getuid()
+        gid = os.getgid()
+    except Exception:
+        # These aren't available on Windows; but then on Windows we don't have to deal
+        # with the same file ownership problems which require us to match the UID in the
+        # first place.
+        user_args = []
+    else:
+        user_args = ["--user", f"{uid}:{gid}"]
+
+    proc = subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            *user_args,
+            f"{config.DOCKER_REGISTRY}/{image}",
+            *docker_args,
+        ]
+    )
+    return proc.returncode == 0

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,0 +1,48 @@
+import pathlib
+from unittest import mock
+
+from opensafely import execute
+
+
+@mock.patch("opensafely.execute.os")
+def test_execute_main(mock_os, run):
+    mock_os.getuid.return_value = 12345
+    mock_os.getgid.return_value = 67890
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--user",
+            "12345:67890",
+            "ghcr.io/opensafely-core/databuilder:v1",
+            "foo",
+            "bar",
+            "baz",
+        ]
+    )
+    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+
+
+@mock.patch("opensafely.execute.os")
+def test_execute_main_on_windows(mock_os, run):
+    mock_os.getuid.side_effect = AttributeError()
+    mock_os.getgid.side_effect = AttributeError()
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "ghcr.io/opensafely-core/databuilder:v1",
+            "foo",
+            "bar",
+            "baz",
+        ]
+    )
+    execute.main("databuilder:v1", ["foo", "bar", "baz"])


### PR DESCRIPTION
This is for running ad-hoc OpenSAFELY actions. As an illustration, running this command:

    opensafely exec foo:v1 do_something --a=1

Should do roughly the same thing as this action in `project.yaml`:

    my_action:
      run: foo:v1 do_something --a=1

The key difference is that rather than having `needs` and `outputs` control which files are available, we mount the entire workspace in so the command can read and write any files it likes.

This is motivated particularly by a desire to remove friction from the Data Builder tutorial. Being able to run commands, see log and error output immediately, and read and create arbitrary files provides a much smoother on-ramp than forcing everything through `project.yaml`.

It also means we can support commands like Data Builder's `create-dummy-tables` which are development tools that don't fit naturally into `project.yaml` at all.

Note that this command is only usable with images that have been rebuilt using the latest base-docker image, following this change:
https://github.com/opensafely-core/base-docker/pull/17

There are various areas for improvement and expansion here which I haven't attempted to tackle at this stage:

 * Adding an `--entrypoint` argument to allow customising the image entrypoint for debugging purposes.
 * Passing the appropriate product key for the `stata-mp` image.
 * Setting the `OPENSAFELY_BACKEND` environment variable to `expectations` as the local job-runner does.