### PR TITLE
Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
We can't check the dependencies easily, because these are vendored. See #23.