### PR TITLE
feat: Add toggle for `--user uid:gid` in `opensafely exec`

### DIFF
--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -11,13 +11,6 @@ DESCRIPTION = "Run an OpenSAFELY action outside of the `project.yaml` pipeline"
 
 def add_arguments(parser):
     parser.add_argument(
-        "--container-user",
-        dest="container_user_is_enabled",
-        action="store_true",
-        default=False,
-        help="Overrides automatic of host user id and group id or Docker; for rootless Docker",
-    )
-    parser.add_argument(
         "image",
         metavar="IMAGE_NAME:VERSION",
         help="OpenSAFELY image and version (e.g. databuilder:v1)",
@@ -28,28 +21,25 @@ def add_arguments(parser):
         metavar="...",
         help="Any additional arguments to pass to the image",
     )
-    parser.set_defaults()
     return parser
 
 
-def main(image, docker_args, container_user_is_enabled):
+def main(image, docker_args):
     if not docker_preflight_check():
         return False
 
-    user_args = []
-    if not container_user_is_enabled:
-        try:
-            # In order for any files that get created to have the appropriate owner/group we
-            # run the command using the current user's UID/GID
-            uid = os.getuid()
-            gid = os.getgid()
-        except Exception:
-            # These aren't available on Windows; but then on Windows we don't have to deal
-            # with the same file ownership problems which require us to match the UID in the
-            # first place.
-            pass
-        else:
-            user_args = ["--user", f"{uid}:{gid}"]
+    try:
+        # In order for any files that get created to have the appropriate owner/group we
+        # run the command using the current user's UID/GID
+        uid = os.getuid()
+        gid = os.getgid()
+    except Exception:
+        # These aren't available on Windows; but then on Windows we don't have to deal
+        # with the same file ownership problems which require us to match the UID in the
+        # first place.
+        user_args = []
+    else:
+        user_args = ["--user", f"{uid}:{gid}"]
 
     proc = subprocess.run(
         [

--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -24,7 +24,7 @@ def add_arguments(parser):
     return parser
 
 
-def main(image, docker_args):
+def main(image, docker_args, environment=os.environ):
     if not docker_preflight_check():
         return False
 
@@ -40,6 +40,10 @@ def main(image, docker_args):
         user_args = []
     else:
         user_args = ["--user", f"{uid}:{gid}"]
+
+    # Override for rootless Docker permissions.
+    if "OPENSAFELY_EXEC_USE_CONTAINER_USER" in environment:
+        user_args = []
 
     proc = subprocess.run(
         [

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -23,7 +23,7 @@ def test_execute_main(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=False)
 
 
 @mock.patch("opensafely.execute.os")
@@ -43,4 +43,22 @@ def test_execute_main_on_windows(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=False)
+
+
+@mock.patch("opensafely.execute.os")
+def test_execute_main_without_user(mock_os, run):
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "ghcr.io/opensafely-core/databuilder:v1",
+            "foo",
+            "bar",
+            "baz",
+        ]
+   )
+    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=True)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -23,7 +23,7 @@ def test_execute_main(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    execute.main("databuilder:v1", ["foo", "bar", "baz"], environment={})
 
 
 @mock.patch("opensafely.execute.os")
@@ -43,4 +43,28 @@ def test_execute_main_on_windows(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    execute.main("databuilder:v1", ["foo", "bar", "baz"], environment={})
+
+
+@mock.patch("opensafely.execute.os")
+def test_execute_main_with_container_user(mock_os, run):
+    mock_os.getuid.return_value = 12345
+    mock_os.getgid.return_value = 67890
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "ghcr.io/opensafely-core/databuilder:v1",
+            "foo",
+            "bar",
+            "baz",
+        ]
+    )
+    execute.main(
+        "databuilder:v1",
+        ["foo", "bar", "baz"],
+        environment={"OPENSAFELY_EXEC_USE_CONTAINER_USER": "1"},
+    )

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -23,7 +23,7 @@ def test_execute_main(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=False)
+    execute.main("databuilder:v1", ["foo", "bar", "baz"])
 
 
 @mock.patch("opensafely.execute.os")
@@ -43,22 +43,4 @@ def test_execute_main_on_windows(mock_os, run):
             "baz",
         ]
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=False)
-
-
-@mock.patch("opensafely.execute.os")
-def test_execute_main_without_user(mock_os, run):
-    run.expect(["docker", "info"])
-    run.expect(
-        [
-            "docker",
-            "run",
-            "--rm",
-            f"--volume={pathlib.Path.cwd()}:/workspace",
-            "ghcr.io/opensafely-core/databuilder:v1",
-            "foo",
-            "bar",
-            "baz",
-        ]
-   )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"], container_user_is_enabled=True)
+    execute.main("databuilder:v1", ["foo", "bar", "baz"])


### PR DESCRIPTION
As the `exec` option stands, it doesn't work with rootless Docker.

See https://github.com/opensafely-core/opensafely-cli/issues/149#issuecomment-1293513246