### PR TITLE
fix: Write warnings to stderr rather than stdout

### DIFF
--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -197,6 +197,7 @@ def check_version():
     if need_update:
         print(
             f"Warning: the OpenSAFELY docker images for {', '.join(need_update)} actions are out of date - please update by running:\n"
-            "    opensafely pull\n"
+            "    opensafely pull\n",
+            file=sys.stderr,
         )
     return need_update

--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -98,6 +98,7 @@ def check_version():
     if update:
         print(
             f"Warning: there is a newer version of opensafely available ({latest}) - please upgrade by running:\n"
-            "    opensafely upgrade\n"
+            "    opensafely upgrade\n",
+            file=sys.stderr,
         )
     return update

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -128,8 +128,8 @@ def test_check_version_out_of_date(run, capsys):
 
     assert len(pull.check_version()) == 1
     out, err = capsys.readouterr()
-    assert err == ""
-    assert out.splitlines() == [
+    assert out == ""
+    assert err.splitlines() == [
         "Warning: the OpenSAFELY docker images for python actions are out of date - please update by running:",
         "    opensafely pull",
         "",

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -115,8 +115,8 @@ def test_check_version_needs_updating(set_current_version, capsys):
     upgrade.CACHE_FILE.write_text("1.1.0")
     set_current_version("v1.0.0")
     assert upgrade.check_version()
-    out, _ = capsys.readouterr()
-    assert out.splitlines() == [
+    _, err = capsys.readouterr()
+    assert err.splitlines() == [
         "Warning: there is a newer version of opensafely available (1.1.0) - please upgrade by running:",
         "    opensafely upgrade",
         "",


### PR DESCRIPTION
This didn't matter much before we added `opensafely exec`, but now we have that we want to be able to pipe commmand output around and so we need to keep the warnings out of stdout.