### PR TITLE
Finish off `opensafely exec` command

### DIFF
--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -5,6 +5,7 @@ import subprocess
 
 from opensafely._vendor.jobrunner import config
 from opensafely._vendor.jobrunner.cli.local_run import docker_preflight_check
+from opensafely.windows import ensure_tty
 
 
 DESCRIPTION = "Run an OpenSAFELY action outside of the `project.yaml` pipeline"
@@ -42,15 +43,16 @@ def main(image, docker_args):
     else:
         user_args = ["--user", f"{uid}:{gid}"]
 
-    proc = subprocess.run(
-        [
-            "docker",
-            "run",
-            "--rm",
-            f"--volume={pathlib.Path.cwd()}:/workspace",
-            *user_args,
-            f"{config.DOCKER_REGISTRY}/{image}",
-            *docker_args,
-        ]
-    )
+    docker_cmd = [
+        "docker",
+        "run",
+        "--rm",
+        "-it",
+        f"--volume={pathlib.Path.cwd()}:/workspace",
+        *user_args,
+        f"{config.DOCKER_REGISTRY}/{image}",
+        *docker_args,
+    ]
+
+    proc = subprocess.run(ensure_tty(docker_cmd))
     return proc.returncode == 0

--- a/opensafely/windows.py
+++ b/opensafely/windows.py
@@ -1,0 +1,53 @@
+"""Support functions for running on windows."""
+
+import os
+import shutil
+import sys
+
+
+# poor mans debugging because debugging threads on windows is hard
+if os.environ.get("DEBUG", False):
+
+    def debug(msg):
+        # threaded output for some reason needs the carriage return or else
+        # it doesn't reset the cursor.
+        sys.stderr.write("DEBUG: " + msg.replace("\n", "\r\n") + "\r\n")
+        sys.stderr.flush()
+
+else:
+
+    def debug(msg):
+        pass
+
+
+def ensure_tty(docker_cmd):
+    """Ensure that we have a valid tty to use to run docker.
+
+    This is needed as we want the user to be able to kill jupyter with Ctrl-C
+    as normal, which requires a tty on their end.
+
+    Nearly every terminal under the sun gives you a valid tty. Except
+    git-bash's default terminal, which happens to be the one a lot of our users
+    use.
+
+    git-bash provides the `wintpy` tool as a workaround, so detect we are in
+    that situation and use it if so.
+
+    """
+    # Note: we don't use platform.system(), as it uses subprocess.run, and this mucks up our test expectations
+    if sys.platform != "win32":
+        return docker_cmd
+
+    winpty = shutil.which("winpty")
+
+    if winpty is None:
+        # not git-bash
+        return docker_cmd
+
+    if sys.stdin.isatty() and sys.stdout.isatty():
+        # already sorted, possibly user already ran us with winpty
+        return docker_cmd
+
+    debug(f"detected no tty, found winpty at {winpty}, wrapping docker with it")
+    # avoid using explicit path, as it can trip things up.
+    return [winpty, "--"] + docker_cmd

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -170,3 +170,25 @@ def test_execute_main_user_linux_disble(run, monkeypatch):
         winpty=True,
     )
     run_main("-u None databuilder:v1")
+
+
+def test_execute_main_stata_license(run, monkeypatch, no_user):
+    monkeypatch.setattr(execute, "get_stata_license", lambda: "LICENSE")
+
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--env",
+            "STATA_LICENSE",
+            "ghcr.io/opensafely-core/stata-mp",
+            "analysis.do",
+        ],
+        env={"STATA_LICENSE": "LICENSE"},
+        winpty=True,
+    )
+    run_main("stata-mp analysis.do")

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -1,37 +1,46 @@
+import argparse
 import pathlib
+import shlex
 from unittest import mock
+
+import pytest
 
 from opensafely import execute
 
 
 @mock.patch("opensafely.execute.os")
-def test_execute_main(mock_os, run):
+def test_execute_get_default_user(mock_os):
     mock_os.getuid.return_value = 12345
     mock_os.getgid.return_value = 67890
-    run.expect(["docker", "info"])
-    run.expect(
-        [
-            "docker",
-            "run",
-            "--rm",
-            "-it",
-            f"--volume={pathlib.Path.cwd()}:/workspace",
-            "--user",
-            "12345:67890",
-            "ghcr.io/opensafely-core/databuilder:v1",
-            "foo",
-            "bar",
-            "baz",
-        ],
-        winpty=True,
-    )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    assert execute.get_default_user() == "12345:67890"
 
 
 @mock.patch("opensafely.execute.os")
-def test_execute_main_on_windows(mock_os, run):
+def test_execute_main_on_windows(mock_os):
     mock_os.getuid.side_effect = AttributeError()
     mock_os.getgid.side_effect = AttributeError()
+    assert execute.get_default_user() is None
+
+
+@pytest.fixture
+def no_user(monkeypatch):
+    """run a test with both linux and windows values."""
+    monkeypatch.setattr(execute, "DEFAULT_USER", None)
+
+
+def run_main(invocation):
+    """Helper to use argparse then exec.
+
+    This helps us functionally test our logic from a user perspective.
+    """
+    parser = argparse.ArgumentParser()
+    execute.add_arguments(parser)
+    argv = shlex.split(invocation)
+    args = parser.parse_args(argv)
+    return execute.main(**vars(args))
+
+
+def test_execute_main(run, no_user):
     run.expect(["docker", "info"])
     run.expect(
         [
@@ -47,4 +56,117 @@ def test_execute_main_on_windows(mock_os, run):
         ],
         winpty=True,
     )
-    execute.main("databuilder:v1", ["foo", "bar", "baz"])
+    run_main("databuilder:v1 foo bar baz")
+
+
+def test_execute_main_entrypoint(run, no_user):
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--entrypoint=/entrypoint",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("--entrypoint /entrypoint databuilder:v1")
+
+
+def test_execute_main_env(run, no_user):
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--env",
+            "FOO",
+            "--env",
+            "BAR",
+            "--env",
+            "BAZ=1",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("-e=FOO -e BAR --env BAZ=1 databuilder:v1")
+
+
+def test_execute_main_user_windows(run, monkeypatch):
+    monkeypatch.setattr(execute, "DEFAULT_USER", None)
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("databuilder:v1")
+
+
+def test_execute_main_user_linux(run, monkeypatch):
+    monkeypatch.setattr(execute, "DEFAULT_USER", "uid:gid")
+
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--user=uid:gid",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("databuilder:v1")
+
+
+@pytest.mark.parametrize("default", [None, "uid:gid"])
+def test_execute_main_user_cli_arg_overrides(default, run, monkeypatch):
+    monkeypatch.setattr(execute, "DEFAULT_USER", default)
+
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "--user=1234:5678",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("-u 1234:5678 databuilder:v1")
+
+
+def test_execute_main_user_linux_disble(run, monkeypatch):
+    monkeypatch.setattr(execute, "DEFAULT_USER", "uid:gid")
+
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}:/workspace",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+        winpty=True,
+    )
+    run_main("-u None databuilder:v1")

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -14,6 +14,7 @@ def test_execute_main(mock_os, run):
             "docker",
             "run",
             "--rm",
+            "-it",
             f"--volume={pathlib.Path.cwd()}:/workspace",
             "--user",
             "12345:67890",
@@ -21,7 +22,8 @@ def test_execute_main(mock_os, run):
             "foo",
             "bar",
             "baz",
-        ]
+        ],
+        winpty=True,
     )
     execute.main("databuilder:v1", ["foo", "bar", "baz"])
 
@@ -36,11 +38,13 @@ def test_execute_main_on_windows(mock_os, run):
             "docker",
             "run",
             "--rm",
+            "-it",
             f"--volume={pathlib.Path.cwd()}:/workspace",
             "ghcr.io/opensafely-core/databuilder:v1",
             "foo",
             "bar",
             "baz",
-        ]
+        ],
+        winpty=True,
     )
     execute.main("databuilder:v1", ["foo", "bar", "baz"])

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,28 @@
+from opensafely import windows
+
+
+def test_ensure_tty_not_windows(monkeypatch):
+    monkeypatch.setattr(windows.sys, "platform", "linux")
+    assert windows.ensure_tty(["cmd"]) == ["cmd"]
+
+
+def test_ensure_tty_no_winpty(monkeypatch):
+    monkeypatch.setattr(windows.sys, "platform", "win32")
+    monkeypatch.setattr(windows.shutil, "which", lambda x: None)
+    assert windows.ensure_tty(["cmd"]) == ["cmd"]
+
+
+def test_ensure_tty_isatty(monkeypatch):
+    monkeypatch.setattr(windows.sys, "platform", "win32")
+    monkeypatch.setattr(windows.shutil, "which", lambda x: "/path/winpty")
+    monkeypatch.setattr(windows.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(windows.sys.stdout, "isatty", lambda: True)
+    assert windows.ensure_tty(["cmd"]) == ["cmd"]
+
+
+def test_ensure_tty_winpty(monkeypatch):
+    monkeypatch.setattr(windows.sys, "platform", "win32")
+    monkeypatch.setattr(windows.shutil, "which", lambda x: "/path/winpty")
+    monkeypatch.setattr(windows.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(windows.sys.stdout, "isatty", lambda: False)
+    assert windows.ensure_tty(["cmd"]) == ["/path/winpty", "--", "cmd"]


### PR DESCRIPTION
Finish off the `opensafely exec` implementation.

Fixes #149.

Was a bit involved, because windows, mostly the first commit.
