### PR TITLE
fix: add PYTHONPATH=/workspace to jupyter invocation

### DIFF
--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -170,6 +170,9 @@ def main(directory, name, port, no_browser, jupyter_args):
         f"--hostname={name}",
         "--env",
         "HOME=/tmp",
+        # allow importing from the top level
+        "--env",
+        "PYTHONPATH=/workspace",
     ]
 
     debug("docker: " + " ".join(docker_args))

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -19,6 +19,8 @@ def test_jupyter(run, no_user):
             "--hostname=test_jupyter",
             "--env",
             "HOME=/tmp",
+            "--env",
+            "PYTHONPATH=/workspace",
             "ghcr.io/opensafely-core/python",
             "jupyter",
             "lab",


### PR DESCRIPTION
This allows jupyter notebooks to import from the top level directory of
the workspace code.

Fixes #160
