### PR TITLE
fix: refactor periodic update checks

### DIFF
--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -2,8 +2,6 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
-from datetime import datetime, timedelta
 from pathlib import Path
 
 import opensafely
@@ -11,8 +9,6 @@ from opensafely._vendor import requests
 
 
 DESCRIPTION = "Upgrade the opensafely cli tool."
-
-CACHE_FILE = Path(tempfile.gettempdir()) / "opensafely-latest-version"
 
 
 def add_arguments(parser):
@@ -26,7 +22,7 @@ def add_arguments(parser):
 
 def main(version):
     if version == "latest":
-        version = get_latest_version(force=True)
+        version = get_latest_version()
 
     if not need_to_update(version):
         print(f"opensafely is already at version {version}")
@@ -62,20 +58,9 @@ def main(version):
         sys.exit(exc)
 
 
-def get_latest_version(force=False):
-    latest = None
-    two_hours_ago = datetime.utcnow() - timedelta(hours=2)
-
-    if CACHE_FILE.exists():
-        if CACHE_FILE.stat().st_mtime > two_hours_ago.timestamp():
-            latest = CACHE_FILE.read_text().strip()
-
-    if force or latest is None:
-        resp = requests.get("https://pypi.org/pypi/opensafely/json").json()
-        latest = resp["info"]["version"]
-        CACHE_FILE.write_text(latest)
-
-    return latest
+def get_latest_version():
+    resp = requests.get("https://pypi.org/pypi/opensafely/json").json()
+    return resp["info"]["version"]
 
 
 def comparable(version_string):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,18 @@
+import os
+from datetime import datetime, timedelta
+
+import opensafely
+
+
+def test_should_version_check():
+
+    opensafely.VERSION_FILE.unlink(missing_ok=True)
+
+    assert opensafely.should_version_check() is True
+    opensafely.update_version_check()
+    assert opensafely.should_version_check() is False
+
+    timestamp = (datetime.utcnow() - timedelta(hours=5)).timestamp()
+    os.utime(opensafely.VERSION_FILE, (timestamp, timestamp))
+
+    assert opensafely.should_version_check() is True


### PR DESCRIPTION
Added a global check to avoid spamming checking for updates on every
invocation, which was slow.

Remove the specific upgrade/version caching, as is wasn't needed give
the above.

Altogether, much simpler and future proof

Fixes #147 and fixes #37
