### PR TITLE
fix: add default HOME directory for exec command

### DIFF
--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -62,6 +62,14 @@ def add_arguments(parser):
     return parser
 
 
+def in_env_args(var, env):
+    for e in env:
+        if e == var or e.startswith(f"{var}="):
+            return True
+
+    return False
+
+
 def main(
     image,
     entrypoint=None,
@@ -83,7 +91,13 @@ def main(
     if user and user.lower() in ("none", "no", "false"):
         user = False
 
-    docker_args.extend(["--env", "OPENSAFELY_BACKEND=expectations"])
+    if not in_env_args("OPENSAFELY_BACKEND", env):
+        docker_args.extend(["--env", "OPENSAFELY_BACKEND=expectations"])
+
+    if not in_env_args("HOME", env):
+        # ensure there is a writable home directory for the user, so tools like
+        # ipython can use it to store temporary files, e.g. for tab completion
+        docker_args.extend(["--env", "HOME=/tmp"])
 
     for e in env:
         docker_args.extend(["--env", e])

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -19,6 +19,8 @@ def test_execute_main_args(run, no_user):
             f"--volume={pathlib.Path.cwd()}://workspace",
             "--env",
             "OPENSAFELY_BACKEND=expectations",
+            "--env",
+            "HOME=/tmp",
             "--cpus=2.0",
             "--memory=4G",
             "ghcr.io/opensafely-core/databuilder:v1",
@@ -43,6 +45,8 @@ def test_execute_main_entrypoint(run, no_user):
             f"--volume={pathlib.Path.cwd()}://workspace",
             "--env",
             "OPENSAFELY_BACKEND=expectations",
+            "--env",
+            "HOME=/tmp",
             "--entrypoint=/entrypoint",
             "--cpus=2.0",
             "--memory=4G",
@@ -66,6 +70,8 @@ def test_execute_main_env(run, no_user):
             "--env",
             "OPENSAFELY_BACKEND=expectations",
             "--env",
+            "HOME=/tmp",
+            "--env",
             "FOO",
             "--env",
             "BAR",
@@ -77,6 +83,29 @@ def test_execute_main_env(run, no_user):
         ],
     )
     run_main(execute, "-e=FOO -e BAR --env BAZ=1 databuilder:v1")
+
+
+def test_execute_main_env_in_env(run, no_user):
+    run.expect(["docker", "info"])
+    run.expect(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--init",
+            "--label=opensafely",
+            "-it",
+            f"--volume={pathlib.Path.cwd()}://workspace",
+            "--env",
+            "OPENSAFELY_BACKEND=tpp",
+            "--env",
+            "HOME=/foo",
+            "--cpus=2.0",
+            "--memory=4G",
+            "ghcr.io/opensafely-core/databuilder:v1",
+        ],
+    )
+    run_main(execute, "-e OPENSAFELY_BACKEND=tpp -e HOME=/foo databuilder:v1")
 
 
 @pytest.mark.parametrize("default", [None, "uid:gid"])
@@ -96,6 +125,8 @@ def test_execute_main_user_cli_arg_overrides(default, run, monkeypatch):
             f"--volume={pathlib.Path.cwd()}://workspace",
             "--env",
             "OPENSAFELY_BACKEND=expectations",
+            "--env",
+            "HOME=/tmp",
             "--cpus=2.0",
             "--memory=4G",
             "ghcr.io/opensafely-core/databuilder:v1",
@@ -119,6 +150,8 @@ def test_execute_main_user_linux_disble(run, monkeypatch):
             f"--volume={pathlib.Path.cwd()}://workspace",
             "--env",
             "OPENSAFELY_BACKEND=expectations",
+            "--env",
+            "HOME=/tmp",
             "--cpus=2.0",
             "--memory=4G",
             "ghcr.io/opensafely-core/databuilder:v1",
@@ -142,6 +175,8 @@ def test_execute_main_stata_license(run, monkeypatch, no_user):
             f"--volume={pathlib.Path.cwd()}://workspace",
             "--env",
             "OPENSAFELY_BACKEND=expectations",
+            "--env",
+            "HOME=/tmp",
             "--env",
             "STATA_LICENSE",
             "--cpus=2.0",


### PR DESCRIPTION
This ensure there is a valid writable HOME dir, which makes interactive
tools like ipython happier

Fixes #184
