### PR TITLE
fix: tweek winpty logic to only be for git-bash

### DIFF
--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -53,6 +53,18 @@ def git_bash_tty_wrapper():
         # already sorted, possibly user already ran us with winpty
         return
 
+    if "MSYSTEM" not in os.environ:
+        # not in MINGW terminal, so we can trust isatty
+        return
+
+    # At this point, we know that we are almost certainly in git-bash terminal on windows.
+    # Because isatty() always returns false in this situation, we don't know if
+    # we have a terminal or not, and we don't know any other way to test.
+    #
+    # So, we chose to always assume a tty in this scenario, so that a bare
+    # `opensafely exec ...` will work as expected. This means that piping input
+    # into `opensafely exec` will not work in this scenario.
+
     # avoid using explicit path, as it can trip things up.
     return [winpty, "--"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 from unittest import mock
 
@@ -34,6 +35,13 @@ def test_git_bash_tty_wrapper_isatty(monkeypatch):
     monkeypatch.setattr(utils.shutil, "which", lambda x: "/path/winpty")
     monkeypatch.setattr(utils.sys.stdin, "isatty", lambda: True)
     monkeypatch.setattr(utils.sys.stdout, "isatty", lambda: True)
+
+
+def test_git_bash_tty_wrapper_not_mingw(monkeypatch):
+    monkeypatch.setattr(utils.sys, "platform", "win32")
+    monkeypatch.setattr(utils.shutil, "which", lambda x: "/path/winpty")
+    monkeypatch.setattr(utils.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(utils.sys.stdout, "isatty", lambda: False)
     assert utils.git_bash_tty_wrapper() is None
 
 
@@ -42,6 +50,7 @@ def test_git_bash_tty_wrapper_winpty(monkeypatch):
     monkeypatch.setattr(utils.shutil, "which", lambda x: "/path/winpty")
     monkeypatch.setattr(utils.sys.stdin, "isatty", lambda: False)
     monkeypatch.setattr(utils.sys.stdout, "isatty", lambda: False)
+    monkeypatch.setitem(os.environ, "MSYSTEM", "foo")
     assert utils.git_bash_tty_wrapper() == ["/path/winpty", "--"]
 
 


### PR DESCRIPTION
Previously, it mistakenly affected all windows terminals, but its only the MINGW terminal provided by git-bash that is horrible.