### PR TITLE
feat: Alias ehrql to databduilder

### DIFF
--- a/opensafely/execute.py
+++ b/opensafely/execute.py
@@ -50,7 +50,7 @@ def add_arguments(parser):
     parser.add_argument(
         "image",
         metavar="IMAGE_NAME:VERSION",
-        help="OpenSAFELY image and version (e.g. databuilder:v1)",
+        help="OpenSAFELY image and version (e.g. ehrql:v0)",
     )
     parser.add_argument(
         "cmd_args",

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -91,6 +91,11 @@ def run_docker(
     if user is None:
         user = DEFAULT_USER
 
+    image_name= image.split(":")[0]
+    alias = config.IMAGE_ALIASES.get(image_name)
+    if alias is not None:
+        image = image.replace(image_name, alias) 
+
     base_cmd = [
         "docker",
         "run",


### PR DESCRIPTION
This is a temporary measure until the work to rename databuilder to ehrql is complete. It means that users can write ehrql:v0 in their project.yaml and opensafely exec commands now

Depends on https://github.com/opensafely-core/job-runner/pull/605