### PR TITLE
fix: Allow openprompt-hrqol to access open_prompt

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -20,4 +20,5 @@ opensafely/ckd-healthcare-use:
   allow: ['ukrr']
 opensafely/isaric-exploration:
   allow: ['isaric']
-  
+opensafely/openprompt-hrqol:
+  allow: ['open_prompt']


### PR DESCRIPTION
This repo is for @hendersonad and @ocarlile's work on OpenPROMPT. When merged, use of ehrQL's `open_prompt` table within this repo will no longer raise a warning, such as opensafely/openprompt-hrqol#10.