### PR TITLE
feat: Allow access to waiting list tables

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -20,3 +20,5 @@ opensafely/openprompt-hrqol:
   allow: ['open_prompt']
 opensafely/openprompt-cohort-profile:
   allow: ['open_prompt']
+opensafely/waiting-list:
+  allow: ['wl_clockstops', 'wl_clockstops_raw', 'wl_openpathways', 'wl_openpathways_raw']


### PR DESCRIPTION
Allows access to the Clock Stops and Open Pathways tables for @alschaffer's opensafely/waiting-list repo.

Closes opensafely/waiting-list#4