### PR TITLE
Add a new codelists check-upstream command

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -98,7 +98,7 @@ def update(codelists_dir=None):
     return True
 
 
-def codelists_dir_check(codelists_dir=None):
+def get_codelists_dir(codelists_dir=None):
     codelists_dir = codelists_dir or Path.cwd() / CODELISTS_DIR
     if not codelists_dir.exists():
         print(f"No '{CODELISTS_DIR}' directory present so nothing to check")
@@ -112,7 +112,7 @@ def check_upstream(codelists_dir=None):
     This runs after the local checks in `check()`, but can also run as a standalone
     command.
     """
-    codelists_dir = codelists_dir_check(codelists_dir)
+    codelists_dir = get_codelists_dir(codelists_dir)
     if codelists_dir is None:
         return True
     codelists_file = codelists_dir / CODELISTS_FILE
@@ -152,7 +152,7 @@ def check_upstream(codelists_dir=None):
 
 
 def check():
-    codelists_dir = codelists_dir_check()
+    codelists_dir = get_codelists_dir()
     if codelists_dir is None:
         return True
 

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from opensafely._vendor import requests
 
 
-DESCRIPTION = "Commands for interacting with https://codelists.opensafely.org/"
+OPENCODELISTS_BASE_URL = "https://www.opencodelists.org"
+DESCRIPTION = f"Commands for interacting with {OPENCODELISTS_BASE_URL}"
 
 CODELISTS_DIR = "codelists"
 CODELISTS_FILE = "codelists.txt"
@@ -197,7 +198,7 @@ def parse_codelist_file(codelists_dir):
             )
         codelist_versions[line_without_version] = line_version
 
-        url = f"https://codelists.opensafely.org/codelist/{line}/"
+        url = f"{OPENCODELISTS_BASE_URL}/codelist/{line}/"
         filename = "-".join(tokens[:-1]) + ".csv"
         codelists.append(
             Codelist(

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -41,10 +41,18 @@ def add_arguments(parser):
     parser_check = subparsers.add_parser(
         "check",
         help=(
-            f"Check that codelists on disk match the specification at "
-            f"{CODELISTS_DIR}/{CODELISTS_FILE}"
+            "Check that codelists on disk match the specification at "
+            f"{CODELISTS_DIR}/{CODELISTS_FILE} and are up-to-date with "
+            "upstream versions"
         ),
     )
+
+    parser_check_upstream = subparsers.add_parser(
+        "check-upstream",
+        help=("Check codelists are up to date with upstream versions"),
+    )
+    parser_check_upstream.set_defaults(function=check_upstream)
+
     parser_check.set_defaults(function=check)
 
 
@@ -90,11 +98,64 @@ def update(codelists_dir=None):
     return True
 
 
-def check():
-    codelists_dir = Path.cwd() / CODELISTS_DIR
+def codelists_dir_check(codelists_dir=None):
+    codelists_dir = codelists_dir or Path.cwd() / CODELISTS_DIR
     if not codelists_dir.exists():
         print(f"No '{CODELISTS_DIR}' directory present so nothing to check")
+        return
+    return codelists_dir
+
+
+def check_upstream(codelists_dir=None):
+    """
+    Check currently downloaded codelists against current OpenCodelists data.
+    This runs after the local checks in `check()`, but can also run as a standalone
+    command.
+    """
+    codelists_dir = codelists_dir_check(codelists_dir)
+    if codelists_dir is None:
         return True
+    codelists_file = codelists_dir / CODELISTS_FILE
+    if not codelists_file.exists():
+        exit_with_error(f"No file found at '{codelists_file}'")
+    manifest_file = codelists_dir / MANIFEST_FILE
+    if not manifest_file.exists():
+        exit_with_prompt(f"No file found at '{manifest_file}'.")
+    post_data = {
+        "codelists": codelists_file.read_text(),
+        "manifest": manifest_file.read_text(),
+    }
+    url = f"{OPENCODELISTS_BASE_URL}/api/v1/check/"
+    response = requests.post(url, post_data).json()
+    status = response["status"]
+
+    if status == "error":
+        # The OpenCodelists check endpoint returns an error in the response data if it
+        # encounters an invalid user, organisation or codelist in the codelists.txt file, or
+        # if any codelists in codelists.csv don't match the expected pattern. These should all
+        # be fixable by `opensafely codelists update`.
+        if "error" in response["data"]:
+            exit_with_prompt(
+                f"Error checking upstream codelists: {response['data']['error']}\n"
+            )
+        if response["data"]["added"] or response["data"]["removed"]:
+            exit_with_prompt(
+                "Codelists have been added or removed\n\n"
+                "For details, run:\n\n  opensafely codelists check\n"
+            )
+        changed = "\n  ".join(response["data"]["changed"])
+        exit_with_prompt(
+            f"Some codelists are out of date\nCodelists affected:\n  {changed}\n"
+        )
+    print("Codelists OK")
+    return True
+
+
+def check():
+    codelists_dir = codelists_dir_check()
+    if codelists_dir is None:
+        return True
+
     codelists = parse_codelist_file(codelists_dir)
     manifest_file = codelists_dir / MANIFEST_FILE
     if not manifest_file.exists():
@@ -147,8 +208,15 @@ def check():
             "A CSV file seems to have been modified since it was downloaded:\n"
             "{}\n".format("\n".join(modified))
         )
-    print("Codelists OK")
-    return True
+
+    try:
+        return check_upstream(codelists_dir)
+    except requests.exceptions.ConnectionError:
+        print(
+            f"Local codelists OK; could not contact {OPENCODELISTS_BASE_URL} for upstream check,"
+            "try again later"
+        )
+        return True
 
 
 def make_temporary_manifest(codelists_dir):

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -69,7 +69,7 @@ def codelists_path(tmp_path):
 def test_codelists_check(mock_check, codelists_path):
     mock_check(response={"status": "ok"})
     os.chdir(codelists_path)
-    codelists.check()
+    assert codelists.check()
 
 
 def test_codelists_check_passes_if_opencodelists_is_down(requests_mock, codelists_path):
@@ -78,7 +78,7 @@ def test_codelists_check_passes_if_opencodelists_is_down(requests_mock, codelist
         exc=requests.exceptions.ConnectionError,
     )
     os.chdir(codelists_path)
-    codelists.check()
+    assert codelists.check()
 
 
 def test_codelists_check_fail_if_list_updated(codelists_path):
@@ -191,7 +191,7 @@ def test_codelists_check_upstream_fails_if_no_manifest_file(tmp_path, mock_check
 def test_codelists_check_upstream(codelists_path, mock_check):
     mocked = mock_check(response={"status": "ok"})
     os.chdir(codelists_path)
-    codelists.check_upstream()
+    assert codelists.check_upstream()
 
     # assert content sent to opencodelists
     assert mocked.called_once

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -26,12 +26,12 @@ def test_codelists_update(tmp_path, requests_mock):
     )
     os.chdir(tmp_path)
     requests_mock.get(
-        "https://codelists.opensafely.org/"
+        "https://www.opencodelists.org/"
         "codelist/project123/codelist456/version2/download.csv",
         text="foo",
     )
     requests_mock.get(
-        "https://codelists.opensafely.org/"
+        "https://www.opencodelists.org/"
         "codelist/user/user123/codelist098/version1/download.csv",
         text="bar",
     )


### PR DESCRIPTION
Fixes #225 
Part of the [plan for dealing with acute codelist rot](https://github.com/orgs/opensafely-core/projects/13/views/1?pane=issue&itemId=42536167)

OpenCodelists now has an endpoint that takes the content of a study repo's codelists.txt and codelists.json, and checks that the data that would be downloaded for the specified codelists is the same as the sha in the codelists.json file.  This is specifically intended to deal with changing VMPs in dm+d codelists, in case new mappings have been introduced since the codelist was downloaded into the study repo.

The new subcommand `check-upstream` just calls the opencodelists endpoint, and can be run on its own.  The existing `opensafely codelists check` command now also runs `check-upstream`, so `check` is a comprehensive check of both local changes that may have occurred, and upstream changes.

If any connection error is encountered during the upstream check, we report it in the output message, but don't fail the check.