### PR TITLE
fix: support multiple versions in pull command

### DIFF
--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -102,7 +102,9 @@ def get_local_images():
         [
             "docker",
             "images",
-            "ghcr.io/opensafely-core/*",
+            "ghcr.io/opensafely-core/*",  # this excludes dev builds
+            "--filter",
+            "label=org.opensafely.action",
             "--no-trunc",
             "--format={{.Repository}}={{.ID}}",
         ],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,7 @@ def run(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fixture.run)
     yield fixture
     if len(fixture) != 0:
-        remaining = "\n".join(str(cmd) for cmd, _ in fixture)
+        remaining = "\n".join(str(f[0]) for f in fixture if f)
         raise AssertionError(
             f"run fixture had unused remaining expected cmds:\n{remaining}"
         )


### PR DESCRIPTION
- Add opensafely label in image filters.
- Support v2 python in opensafely pull
