### PR TITLE
fix: Ignore dangling images in opensafely pull

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -3,7 +3,7 @@
 ## Vendoring
 
 To minimise the possibility for installation issues this package vendors
-all its dependencies under the [opensafely._vendor](./opensafely/_vendor)
+all its dependencies under the [`opensafely._vendor`](./opensafely/_vendor)
 namespace using the [vendoring](https://pypi.org/project/vendoring/) tool.
 
 This brings its own complexities (particularly around the `requests`
@@ -23,9 +23,9 @@ To update the vendored version of job-runner:
    ```
 
 2. Run the update script. It will default to latest tag, but you can pass
-   a specific job-runner tag.  
+   a specific job-runner tag.
    ```
-   ./scripts/update.sh [version_tag] 
+   ./scripts/update.sh [version_tag]
    ```
 
 3. Commit the results
@@ -46,7 +46,7 @@ known as "software engineering".
 
 ## Releases
 
-New versions are tagged, and the PyPI package built and published, automatically 
-via GitHub actions on merges to `main`.  Note that the version will be bumped 
+New versions are tagged, and the PyPI package built and published, automatically
+via GitHub actions on merges to `main`.  Note that the version will be bumped
 according to information parsed from the commits using semantic-release conventions (e.g. `fix:`, `feat:`).  If no semantic commit is found since the last tag, a new version
 will not be released.

--- a/opensafely/info.py
+++ b/opensafely/info.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 
 import opensafely
+from opensafely import pull
 
 
 DESCRIPTION = "Print information about the opensafely tool and available resources"
@@ -21,6 +22,7 @@ docker cpu: {cpu}
 
 
 def main():
+    print("System information:")
     try:
         ps = subprocess.run(
             ["docker", "info", "-f", "{{json .}}"], capture_output=True, text=True
@@ -38,3 +40,14 @@ def main():
         )
     except Exception:
         sys.exit("Error retreiving docker information")
+
+    print("OpenSAFELY Docker image versions:")
+    try:
+        local_images = pull.get_local_images()
+        updates = pull.check_version(local_images)
+    except Exception:
+        sys.exit("Error retreiving image information")
+    else:
+        for image, sha in sorted(local_images.items()):
+            update = "(needs update)" if image in updates else "(latest version)"
+            print(f" - {image:24}: {sha[7:15]} {update}")

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -126,6 +126,8 @@ def get_local_images():
             "ghcr.io/opensafely-core/*",  # this excludes dev builds
             "--filter",
             "label=org.opensafely.action",
+            "--filter",
+            "dangling=false",  # these will be pruned
             "--no-trunc",
             "--format={{.Repository}}:{{.Tag}}={{.ID}}",
         ],

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -222,10 +222,4 @@ def check_version():
         if latest_sha != local_sha:
             need_update.append(image)
 
-    if need_update:
-        print(
-            f"Warning: the OpenSAFELY docker images for {', '.join(need_update)} actions are out of date - please update by running:\n"
-            "    opensafely pull\n",
-            file=sys.stderr,
-        )
     return need_update

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -214,9 +214,10 @@ def get_auth_token(header):
     return auth_response.json()["token"]
 
 
-def check_version():
+def check_version(local_images=None):
     need_update = []
-    local_images = get_local_images()
+    if local_images is None:
+        local_images = get_local_images()
 
     for image, local_sha in local_images.items():
         name, _, tag = image.partition(":")

--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -80,11 +80,7 @@ def need_to_update(latest):
 
 def check_version():
     latest = get_latest_version()
-    update = need_to_update(latest)
-    if update:
-        print(
-            f"Warning: there is a newer version of opensafely available ({latest}) - please upgrade by running:\n"
-            "    opensafely upgrade\n",
-            file=sys.stderr,
-        )
-    return update
+    if need_to_update(latest):
+        return latest
+    else:
+        return False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@ import os
 from datetime import datetime, timedelta
 
 import opensafely
+from tests.test_pull import expect_local_images
 
 
 def test_should_version_check():
@@ -15,3 +16,39 @@ def test_should_version_check():
     os.utime(opensafely.VERSION_FILE, (timestamp, timestamp))
 
     assert opensafely.should_version_check() is True
+
+
+def test_warn_if_updates_needed_package_outdated(
+    capsys, monkeypatch, tmp_path, set_current_version, set_pypi_version
+):
+
+    set_pypi_version("1.1.0")
+    set_current_version("v1.0.0")
+    monkeypatch.setattr(opensafely, "VERSION_FILE", tmp_path / "timestamp")
+    opensafely.warn_if_updates_needed(["opensafely"])
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err.splitlines() == [
+        "Warning: there is a newer version of opensafely available (1.1.0) - please upgrade by running:",
+        "    opensafely upgrade",
+        "",
+    ]
+
+
+def test_warn_if_updates_needed_images_outdated(capsys, monkeypatch, tmp_path, run):
+    monkeypatch.setattr(opensafely, "VERSION_FILE", tmp_path / "timestamp")
+    expect_local_images(
+        run,
+        stdout="ghcr.io/opensafely-core/python:latest=sha256:oldsha",
+    )
+
+    opensafely.warn_if_updates_needed(["opensafely"])
+
+    out, err = capsys.readouterr()
+    assert out == ""
+    assert err.splitlines() == [
+        "Warning: the OpenSAFELY docker images for python:latest actions are out of date - please update by running:",
+        "    opensafely pull",
+        "",
+    ]

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -21,6 +21,8 @@ def expect_local_images(run, stdout="", **kwargs):
             "ghcr.io/opensafely-core/*",
             "--filter",
             "label=org.opensafely.action",
+            "--filter",
+            "dangling=false",
             "--no-trunc",
             "--format={{.Repository}}:{{.Tag}}={{.ID}}",
         ],

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -166,23 +166,15 @@ def test_remove_deprecated_images(run):
     pull.remove_deprecated_images(local_images)
 
 
-def test_check_version_out_of_date(run, capsys):
+def test_check_version_out_of_date(run):
     expect_local_images(
         run,
         stdout="ghcr.io/opensafely-core/python:latest=sha256:oldsha",
     )
-
     assert len(pull.check_version()) == 1
-    out, err = capsys.readouterr()
-    assert out == ""
-    assert err.splitlines() == [
-        "Warning: the OpenSAFELY docker images for python:latest actions are out of date - please update by running:",
-        "    opensafely pull",
-        "",
-    ]
 
 
-def test_check_version_up_to_date(run, capsys):
+def test_check_version_up_to_date(run):
     current_sha = pull.get_remote_sha("ghcr.io/opensafely-core/python", "latest")
     pull.token = None
     expect_local_images(
@@ -191,9 +183,6 @@ def test_check_version_up_to_date(run, capsys):
     )
 
     assert len(pull.check_version()) == 0
-    out, err = capsys.readouterr()
-    assert err == ""
-    assert out.splitlines() == []
 
 
 def test_get_actions_from_project_yaml_no_actions():

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -43,24 +43,16 @@ def test_need_to_update(set_current_version):
     assert upgrade.need_to_update("1.11.0")
 
 
-def test_check_version_needs_updating(set_current_version, set_pypi_version, capsys):
+def test_check_version_needs_updating(set_current_version, set_pypi_version):
     set_pypi_version("1.1.0")
     set_current_version("v1.0.0")
     assert upgrade.check_version()
-    _, err = capsys.readouterr()
-    assert err.splitlines() == [
-        "Warning: there is a newer version of opensafely available (1.1.0) - please upgrade by running:",
-        "    opensafely upgrade",
-        "",
-    ]
 
 
-def test_check_version_not_need_updating(set_current_version, set_pypi_version, capsys):
+def test_check_version_not_need_updating(set_current_version, set_pypi_version):
     set_pypi_version("1.0.0")
     set_current_version("v1.0.0")
     assert not upgrade.check_version()
-    out, _ = capsys.readouterr()
-    assert out.strip() == ""
 
 
 @pytest.mark.parametrize(

--- a/tests/test_upgrade.py
+++ b/tests/test_upgrade.py
@@ -2,37 +2,8 @@ import argparse
 import sys
 
 import pytest
-from requests_mock import mocker
 
-import opensafely
 from opensafely import upgrade
-from opensafely._vendor import requests
-
-
-# Because we're using a vendored version of requests we need to monkeypatch the
-# requests_mock library so it references our vendored library instead
-mocker.requests = requests
-mocker._original_send = requests.Session.send
-
-
-@pytest.fixture
-def set_current_version(monkeypatch):
-    def set(value):  # noqa: A001
-        assert value[0] == "v", "Current __version__ must start with v"
-        monkeypatch.setattr(opensafely, "__version__", value)
-
-    yield set
-
-
-@pytest.fixture
-def set_pypi_version(requests_mock):
-    def set(version):  # noqa: A001
-        requests_mock.get(
-            "https://pypi.org/pypi/opensafely/json",
-            json={"info": {"version": version}},
-        )
-
-    return set
 
 
 def test_main_latest_upgrade(set_pypi_version, run, set_current_version):


### PR DESCRIPTION
The primary purpose of this PR is to ignore dangling images, and thus un-break
`opensafely pull` for some users.

Also included is a related UX improvement to the `opensafely info` command, as
this would have helped diagnose the problems.

This also involved some clean up refactoring, moving the responsibility for
printing warnings to where it belongs.

