### PR TITLE
fix: older docker doesn't support dangling=false filter

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -57,7 +57,7 @@ jobs:
         python setup.py sdist bdist_wheel
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # v1.90
       if: needs.tag-new-version.outputs.tag
       with:
         user: __token__

--- a/opensafely/info.py
+++ b/opensafely/info.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-import sys
 
 import opensafely
 from opensafely import pull
@@ -38,15 +37,15 @@ def main():
                 cpu=info["NCPU"],
             )
         )
-    except Exception:
-        sys.exit("Error retreiving docker information")
+    except Exception as exc:
+        raise RuntimeError(f"Error retreiving docker information: {exc}")
 
     print("OpenSAFELY Docker image versions:")
     try:
         local_images = pull.get_local_images()
         updates = pull.check_version(local_images)
-    except Exception:
-        sys.exit("Error retreiving image information")
+    except Exception as exc:
+        raise RuntimeError(f"Error retreiving image information: {exc}")
     else:
         for image, sha in sorted(local_images.items()):
             update = "(needs update)" if image in updates else "(latest version)"

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -139,6 +139,9 @@ def get_local_images():
     for line in ps.stdout.splitlines():
         if not line.strip():
             continue
+        # dangling=false does not work on older versions of docker, so manually do it
+        if "<none>" in line:
+            continue
 
         line = line.replace("ghcr.io/opensafely-core/", "")
 

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -101,6 +101,16 @@ def test_default_with_local_images(run, capsys):
     ]
 
 
+def test_default_with_old_docker(run, capsys):
+    run.expect(["docker", "info"])
+    expect_local_images(run, stdout="ghcr.io/opensafely-core/r:<none>=sha")
+
+    pull.main(image="all", force=False)
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert out.strip() == "No OpenSAFELY docker images found to update."
+
+
 def test_specific_image(run, capsys):
     run.expect(["docker", "info"])
     expect_local_images(run)


### PR DESCRIPTION
- **fix: attempt to fix release action**
- **fix: manually filter for dangling images for older dockers**
- **Make info command throw exceptions rather than handle them**