### PR TITLE
Minor fixes for jupyter subcommand

### DIFF
--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -175,6 +175,8 @@ def main(directory, name, port, no_browser, jupyter_args):
     ]
 
     debug("docker: " + " ".join(docker_args))
-    ps = utils.run_docker(docker_args, "python", jupyter_cmd, interactive=True)
+    ps = utils.run_docker(
+        docker_args, "python", jupyter_cmd, interactive=True, directory=directory
+    )
     # we want to exit with the same code that jupyter did
     return ps.returncode


### PR DESCRIPTION
* Bind socket to loopback interface (as per security advisory from rstudio subcommand PR)
* Fix `opensafely jupyter --directory` argument not being passed through to `utils.run_docker()`