### PR TITLE
Make it possible to install with `uv`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install `uv`
+      uses: astral-sh/setup-uv@f3bcaebff5eace81a1c062af9f9011aae482ca9d # v3.1.7
+      with:
+        version: "0.4.20"
     - name: Install dependencies
       run: |
         python -m pip install -r requirements.dev.txt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.os }}
     name: Run test suite
     steps:

--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -65,10 +65,15 @@ def warn_if_updates_needed(argv):
         try:
             latest = upgrade.check_version()
             if latest:
+                upgrade_command = (
+                    "uv tool upgrade opensafely"
+                    if upgrade.is_installed_with_uv()
+                    else "opensafely upgrade"
+                )
                 print(
                     f"Warning: there is a newer version of opensafely available ({latest})"
-                    " - please upgrade by running:\n"
-                    "    opensafely upgrade\n",
+                    f" - please upgrade by running:\n"
+                    f"    {upgrade_command}\n",
                     file=sys.stderr,
                 )
                 # if we're out of date, don't warn the user about out of date images as well

--- a/opensafely/upgrade.py
+++ b/opensafely/upgrade.py
@@ -28,6 +28,17 @@ def main(version):
         print(f"opensafely is already at version {version}")
         return 0
 
+    if is_installed_with_uv():
+        print(
+            "The OpenSAFELY tool has been installed using `uv` so cannot be directly"
+            " upgraded.\n"
+            "\n"
+            "Instead, please run:\n"
+            "\n"
+            "    uv tool upgrade opensafely\n"
+        )
+        return 1
+
     # Windows shennanigans: pip triggers a permissions error when it tries to
     # update the currently executing binary. However if we replace the binary
     # with a copy of itself (i.e. copy to a temporary file and then move the
@@ -84,3 +95,10 @@ def check_version():
         return latest
     else:
         return False
+
+
+def is_installed_with_uv():
+    # This was the most robust way I could think of for detecting a `uv` installation.
+    # I'm reasonably confident in its specificity. It's possible that a `uv` change will
+    # cause this to give false negatives, but the tests should catch that.
+    return Path(sys.prefix).joinpath("uv-receipt.toml").exists()

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,9 @@ setup(
     author="OpenSAFELY",
     author_email="tech@opensafely.org",
     python_requires=">=3.8",
+    install_requires=[
+        "setuptools",
+    ],
     entry_points={"console_scripts": ["opensafely=opensafely:main"]},
     classifiers=["License :: OSI Approved :: GNU General Public License v3 (GPLv3)"],
     project_urls={

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -6,14 +6,31 @@ from pathlib import Path, PurePath
 
 import pytest
 
+import opensafely
+
 
 BIN_DIR = "bin" if os.name != "nt" else "Scripts"
 
 project_fixture_path = Path(__file__).parent / "fixtures" / "projects"
 
 
+@pytest.fixture
+def older_version_file():
+    # This is really not very nice, but short of reworking the way versioning is handled
+    # (which I don't want to do at the moment) I can't think of another way. In order to
+    # build a package with the right version (both in the metadata and in the code
+    # itself) we need to temporarily update the VERSION file.
+    version_file_path = Path(opensafely.__file__).parent / "VERSION"
+    orig_contents = version_file_path.read_bytes()
+    try:
+        version_file_path.write_text("0.1")
+        yield
+    finally:
+        version_file_path.write_bytes(orig_contents)
+
+
 @pytest.mark.parametrize("package_type", ["sdist", "bdist_wheel"])
-def test_packaging(package_type, tmp_path):
+def test_packaging(package_type, tmp_path, older_version_file):
     package_path = build_package(package_type)
     # Install it in a temporary virtualenv
     subprocess_run([sys.executable, "-m", "venv", tmp_path], check=True)
@@ -27,9 +44,6 @@ def test_packaging(package_type, tmp_path):
     # vendoring and packaging, issues tend to show up at import time.
     subprocess_run([tmp_path / BIN_DIR / "opensafely", "run", "--help"], check=True)
     subprocess_run([tmp_path / BIN_DIR / "opensafely", "--version"], check=True)
-    # This always triggers an upgrade because the development version is always
-    # considered lower than any other version
-    subprocess_run([tmp_path / BIN_DIR / "opensafely", "upgrade", "1.7.0"], check=True)
 
     # only on linux, as that has docker installed in GH
     if sys.platform == "linux":
@@ -39,6 +53,17 @@ def test_packaging(package_type, tmp_path):
             check=True,
             cwd=str(project_fixture_path),
         )
+
+    # This always triggers an upgrade because the development version is always
+    # considered lower than any other version
+    result = subprocess_run(
+        [tmp_path / BIN_DIR / "opensafely", "upgrade"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "Attempting uninstall: opensafely" in result.stdout
+    assert "Successfully installed opensafely" in result.stdout
 
 
 def build_package(package_type):


### PR DESCRIPTION
As a first step in exploring the `uv` story we make the minimal changes necessary to ensure that everything works correctly under `uv` with a recent version of Python. This involves:
 * making explicit our implicit dependency on `setuptools`;
 * prompting the user to upgrade by running `uv tool upgrade opensafely` rather than `opensafely upgrade` if they've used `uv` rather than `pip` to install it.

These changes ought to be invisible to existing users, but they mean it's now possible to get some users to try out `uv` on an experimental basis.

There's very little change in the production code here: as you might expect, most of the shenanigans are with the tests.

Relates to #277
