### PR TITLE
fix: test and fix error handling in open_browser

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import logging
+import os
 import sys
 import tempfile
 from datetime import datetime, timedelta
@@ -150,6 +151,9 @@ def main():
 
     function = kwargs.pop("function")
     debug = kwargs.pop("global_debug")
+
+    if debug:
+        os.environ["DEBUG"] = "true"
 
     try:
         success = function(**kwargs)

--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -47,14 +47,14 @@ def add_arguments(parser):
     )
 
 
-def get_metadata(name):
+def get_metadata(name, timeout=30.0):
     """Read the login token from the generated json file in the container"""
     metadata = None
     metadata_path = "/tmp/.local/share/jupyter/runtime/nbserver-*.json"
 
     # wait for jupyter to be set up
     start = time.time()
-    while metadata is None and time.time() - start < 120.0:
+    while metadata is None and time.time() - start < timeout:
         ps = subprocess.run(
             ["docker", "exec", name, "bash", "-c", f"cat {metadata_path}"],
             text=True,

--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import os
 import subprocess
+import sys
 import time
 from pathlib import Path
 
@@ -80,8 +81,8 @@ def read_metadata_and_open(name, port):
             utils.open_browser(url)
         else:
             utils.debug("could not retrieve login token from jupyter container")
-    except Exception as exc:
-        utils.print_exception_from_thread(exc)
+    except Exception:
+        utils.print_exception_from_thread(*sys.exc_info())
 
 
 def main(directory, name, port, no_browser, jupyter_args):

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -165,12 +165,12 @@ def get_free_port():
     return port
 
 
-def print_exception_from_thread(exc):
+def print_exception_from_thread(*exc_info):
     # reformat exception printing to work from thread in windows
     import traceback
 
     sys.stderr.write("Error in background thread:\r\n")
-    tb = traceback.format_exc(exc).replace("\n", "\r\n")
+    tb = "".join(traceback.format_exception(*exc_info)).replace("\n", "\r\n")
     sys.stderr.write(tb)
     sys.stderr.flush()
 
@@ -198,8 +198,8 @@ def open_browser(url, timeout=60.0):
         debug("open_browser: open_browser: opening browser window")
         webbrowser.open(url, new=2)
 
-    except Exception as exc:
-        print_exception_from_thread(exc)
+    except Exception:
+        print_exception_from_thread(*sys.exc_info())
 
 
 def open_in_thread(target, args):

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -169,7 +169,7 @@ def print_exception_from_thread(*exc_info):
     sys.stderr.flush()
 
 
-def open_browser(url, timeout=60.0):
+def open_browser(url, timeout=30.0):
     try:
         debug(f"open_browser: url={url}")
 

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -176,11 +176,12 @@ def open_browser(url, timeout=60.0):
         # wait for port to be open
         debug("open_browser: waiting for port")
         start = time.time()
+        response = None
         while time.time() - start < timeout:
             try:
                 response = requests.get(url, timeout=1)
             except Exception:
-                pass
+                time.sleep(0.5)
             else:
                 break
 

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -9,8 +9,8 @@ import sys
 import threading
 import time
 import webbrowser
-from urllib import request
 
+from opensafely._vendor import requests
 from opensafely._vendor.jobrunner import config
 
 
@@ -166,7 +166,7 @@ def get_free_port():
 
 
 def print_exception_from_thread(exc):
-    # reformat exception printing to work from thread
+    # reformat exception printing to work from thread in windows
     import traceback
 
     sys.stderr.write("Error in background thread:\r\n")
@@ -175,17 +175,17 @@ def print_exception_from_thread(exc):
     sys.stderr.flush()
 
 
-def open_browser(url):
+def open_browser(url, timeout=60.0):
     try:
         debug(f"open_browser: url={url}")
 
         # wait for port to be open
         debug("open_browser: waiting for port")
         start = time.time()
-        while time.time() - start < 60.0:
+        while time.time() - start < timeout:
             try:
-                response = request.urlopen(url, timeout=1)
-            except (request.URLError, OSError):
+                response = requests.get(url, timeout=1)
+            except Exception:
                 pass
             else:
                 break

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -14,19 +14,13 @@ from opensafely._vendor import requests
 from opensafely._vendor.jobrunner import config
 
 
-# poor mans debugging because debugging threads on windows is hard
-if os.environ.get("DEBUG", False):
-
-    def debug(msg):
+def debug(msg):
+    """Windows threaded debugger."""
+    if os.environ.get("DEBUG", False):
         # threaded output for some reason needs the carriage return or else
         # it doesn't reset the cursor.
         sys.stderr.write("DEBUG: " + msg.replace("\n", "\r\n") + "\r\n")
         sys.stderr.flush()
-
-else:
-
-    def debug(msg):
-        pass
 
 
 def get_default_user():
@@ -191,11 +185,13 @@ def open_browser(url, timeout=60.0):
                 break
 
         if not response:
-            debug("open_browser: open_browser: could not get response")
+            # always write a failure message
+            sys.stderr.write(f"Could not connect to {url} to open browser\r\n")
+            sys.stderr.flush()
             return
 
         # open a webbrowser pointing to the docker container
-        debug("open_browser: open_browser: opening browser window")
+        debug("open_browser: opening browser window")
         webbrowser.open(url, new=2)
 
     except Exception:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 82
+fail_under = 88
 skip_covered = true
 show_missing = true
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -43,7 +43,7 @@ def test_jupyter(run, no_user, monkeypatch):
             "foo",
         ]
     )
-    # fetach the metadata
+    # fetch the metadata
     run.expect(
         [
             "docker",

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -1,10 +1,19 @@
 import pathlib
+from unittest import mock
 
-from opensafely import jupyter
+from opensafely import jupyter, utils
 from tests.conftest import run_main
 
 
-def test_jupyter(run, no_user):
+def test_jupyter(run, no_user, monkeypatch):
+    # easier to monkeypatch open_browser that try match the underlying
+    # subprocess calls.
+    mock_open_browser = mock.Mock(spec=utils.open_browser)
+    monkeypatch.setattr(utils, "open_browser", mock_open_browser)
+
+    # these calls are done in different threads, so can come in any order
+    run.concurrent = True
+
     run.expect(
         [
             "docker",
@@ -34,5 +43,18 @@ def test_jupyter(run, no_user):
             "foo",
         ]
     )
+    # fetach the metadata
+    run.expect(
+        [
+            "docker",
+            "exec",
+            "test_jupyter",
+            "bash",
+            "-c",
+            "cat /tmp/.local/share/jupyter/runtime/nbserver-*.json",
+        ],
+        stdout='{"token": "TOKEN"}',
+    )
 
-    assert run_main(jupyter, "--port 1234 --name test_jupyter --no-browser foo") == 0
+    assert run_main(jupyter, "--port 1234 --name test_jupyter foo") == 0
+    mock_open_browser.assert_called_with("http://localhost:1234/?token=TOKEN")

--- a/tests/test_rstudio.py
+++ b/tests/test_rstudio.py
@@ -19,7 +19,7 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists):
     # windows
     monkeypatch.setitem(os.environ, "USERPROFILE", str(home))
 
-    # mock the webbrowser.open call
+    # mock the open_browser call
     mock_open_browser = mock.Mock(spec=utils.open_browser)
     monkeypatch.setattr(utils, "open_browser", mock_open_browser)
 

--- a/tests/test_rstudio.py
+++ b/tests/test_rstudio.py
@@ -1,10 +1,11 @@
 import os
 import pathlib
 from sys import platform
+from unittest import mock
 
 import pytest
 
-from opensafely import rstudio
+from opensafely import rstudio, utils
 from tests.conftest import run_main
 
 
@@ -17,6 +18,10 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists):
     monkeypatch.setitem(os.environ, "HOME", str(home))
     # windows
     monkeypatch.setitem(os.environ, "USERPROFILE", str(home))
+
+    # mock the webbrowser.open call
+    mock_open_browser = mock.Mock(spec=utils.open_browser)
+    monkeypatch.setattr(utils, "open_browser", mock_open_browser)
 
     if gitconfig_exists:
         (home / ".gitconfig").touch()
@@ -55,3 +60,4 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists):
     run.expect(expected + ["ghcr.io/opensafely-core/rstudio"])
 
     assert run_main(rstudio, "--port 8787 --name test_rstudio") == 0
+    mock_open_browser.assert_called_with("http://localhost:8787")


### PR DESCRIPTION
This fixes an ugly message for a user when something didn't work right.

There were two errors:
 - a missing default definition of `response`
 - the special formatting of exceptions was broken.

These were not covered by tests, as it was awkward to do. But its caused
breakage, so this PR grasps the nettle and adds coverage for:

 - rstudio command opening the browser
 - jupyter command getting metadata and opening the browser
 - `open_browser` error cases

This required some refactoring of the SubprocessRunFixture, and some other
clean ups.

As a result, test coverage went up by 6%.

- **Refactor SubprocessRunFixture to handle concurrent declarations**
- **Explicitly mock open_browser call in test_rstudio.py**
- **Fully mock/test jupyter browser calls**
- **use requests rather than urllib, as its easier to use**
- **fix: fix issue in exception rendering refactor**
- **Refactor threaded debugging to work for testing**
- **Test and fix the open_browser error handling**
- **bump coverage minimum up 6 to 88**
