### PR TITLE
Add Docker preflight check to opensafely jupyter and rstudio subcommands

### DIFF
--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -7,6 +7,7 @@ import time
 from pathlib import Path
 
 from opensafely import utils
+from opensafely._vendor.jobrunner.cli.local_run import docker_preflight_check
 
 
 DESCRIPTION = "Run a jupyter lab notebook using the OpenSAFELY environment"
@@ -86,6 +87,9 @@ def read_metadata_and_open(name, port):
 
 
 def main(directory, name, port, no_browser, jupyter_args):
+    if not docker_preflight_check():
+        return False
+
     if name is None:
         name = f"os-jupyter-{directory.name}"
 

--- a/opensafely/rstudio.py
+++ b/opensafely/rstudio.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from sys import platform
 
 from opensafely import utils
+from opensafely._vendor.jobrunner.cli.local_run import docker_preflight_check
 
 
 DESCRIPTION = "Run an RStudio Server session using the OpenSAFELY environment"
@@ -29,6 +30,9 @@ def add_arguments(parser):
 
 
 def main(directory, name, port):
+    if not docker_preflight_check():
+        return False
+
     if name is None:
         name = f"os-rstudio-{directory.name}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ omit = [
 ]
 
 [tool.coverage.report]
-fail_under = 88
+fail_under = 87
 skip_covered = true
 show_missing = true
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -14,6 +14,8 @@ def test_jupyter(run, no_user, monkeypatch):
     # these calls are done in different threads, so can come in any order
     run.concurrent = True
 
+    run.expect(["docker", "info"])
+
     run.expect(
         [
             "docker",

--- a/tests/test_rstudio.py
+++ b/tests/test_rstudio.py
@@ -31,6 +31,8 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists):
     else:
         uid = None
 
+    run.expect(["docker", "info"])
+
     run.expect(["docker", "image", "inspect", "ghcr.io/opensafely-core/rstudio:latest"])
 
     expected = [


### PR DESCRIPTION
Adds a call to `docker_preflight_check()` at the beginning of the `opensafely jupyter` and `opensafely rstudio` subcommands. 

This ensures they give the same error message as `opensafely run` if they are started without Docker installed or running.

I had to move the coverage target back down 1 to 87.