### PR TITLE
feat: add --background and --force options to launch command

### DIFF
--- a/opensafely/jupyter.py
+++ b/opensafely/jupyter.py
@@ -1,12 +1,9 @@
-from opensafely import launch
-
-
 DESCRIPTION = "DEPRECATED. Use: opensafely launch jupyter"
 
-add_arguments = launch.add_base_args
+add_arguments = lambda _: None
 
 
-def main(directory, name, port, no_browser):
+def main(*args, **kwargs):
     print(
         "opensafely jupyter command is deprecated - instead use: opensafely launch jupyter"
     )

--- a/opensafely/launch.py
+++ b/opensafely/launch.py
@@ -126,8 +126,7 @@ def launch_jupyter(version, directory, name, port, no_browser, background):
         "--Application.log_level=ERROR",  # only log errors
     ]
 
-    print(f"Running following jupyter cmd in OpenSAFELY docker container {name}...")
-    print(" ".join(jupyter_cmd))
+    utils.debug(" ".join(jupyter_cmd))
 
     docker_args = [
         # we use our port on both sides of the docker port mapping so that
@@ -206,7 +205,6 @@ def launch_rstudio(version, directory, name, port, no_browser, background):
         directory=directory,
     )
 
-    utils.debug("docker: " + " ".join(docker_args))
     print(f"Opening an RStudio Server session at {url}.")
     return run_tool(docker_args, kwargs, background, no_browser, url)
 

--- a/opensafely/launch.py
+++ b/opensafely/launch.py
@@ -119,10 +119,11 @@ def launch_jupyter(version, directory, name, port, no_browser, background):
         "lab",
         "--ip=0.0.0.0",
         f"--port={port}",
-        "--allow-root",
-        "--no-browser",
+        "--no-browser",  # we open the brower
         # display the url from the hosts perspective
-        f"--LabApp.custom_display_url=http://localhost:{port}/",
+        f"--ServerApp.custom_display_url=http://localhost:{port}/",
+        "-y",  # do not ask for confirmation on quiting
+        "--Application.log_level=ERROR",  # only log errors
     ]
 
     print(f"Running following jupyter cmd in OpenSAFELY docker container {name}...")

--- a/opensafely/launch.py
+++ b/opensafely/launch.py
@@ -1,7 +1,6 @@
 import argparse
 import os
 import secrets
-import subprocess
 import sys
 from pathlib import Path
 
@@ -166,22 +165,6 @@ def launch_rstudio(version, directory, name, port, no_browser, background):
         uid = os.getuid()
     else:
         uid = None
-
-    # check for rstudio image, if not present pull image
-    imgchk = subprocess.run(
-        ["docker", "image", "inspect", f"ghcr.io/opensafely-core/rstudio:{version}"],
-        capture_output=True,
-    )
-    if imgchk.returncode == 1:
-        subprocess.run(
-            [
-                "docker",
-                "pull",
-                "--platform=linux/amd64",
-                f"ghcr.io/opensafely-core/rstudio:{version}",
-            ],
-            check=True,
-        )
 
     docker_args = [
         f"-p={port}:8787",

--- a/opensafely/launch.py
+++ b/opensafely/launch.py
@@ -118,10 +118,10 @@ def launch_jupyter(version, directory, name, port, no_browser, background):
         "lab",
         "--ip=0.0.0.0",
         f"--port={port}",
-        "--no-browser",  # we open the brower
+        "--no-browser",  # we open the browser
         # display the url from the hosts perspective
         f"--ServerApp.custom_display_url=http://localhost:{port}/",
-        "-y",  # do not ask for confirmation on quiting
+        "-y",  # do not ask for confirmation on quitting
         "--Application.log_level=ERROR",  # only log errors
     ]
 

--- a/opensafely/rstudio.py
+++ b/opensafely/rstudio.py
@@ -1,12 +1,9 @@
-from opensafely import launch
-
-
 DESCRIPTION = "DEPRECATED. Use: opensafely launch rstudio"
 
-add_arguments = launch.add_base_args
+add_arguments = lambda _: None
 
 
-def main(directory, name, port, no_browser):
+def main(*args, **kwargs):
     print(
         "opensafely rstudio command is deprecated - instead use: opensafely launch rstudio"
     )

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -157,6 +157,28 @@ def run_docker(
     return subprocess.run(docker_cmd, *args, **kwargs)
 
 
+def dockerctl(cmd, *args, check=True, capture_output=True, text=True, **kwargs):
+    """Utility function to docker commands that are *not* run.
+
+    Sets some defaults:
+     - check=True
+     - capture_output=True
+     - text=True
+
+    Also ensures
+    """
+
+    assert cmd != "run", "Use run_docker not dockerctl"
+
+    return subprocess.run(
+        ["docker", cmd] + list(args),
+        check=check,
+        capture_output=capture_output,
+        text=text,
+        **kwargs,
+    )
+
+
 def get_free_port():
     """Get a port that is free on the users host machine"""
     # this is a race condition, as something else could consume the socket

--- a/opensafely/utils.py
+++ b/opensafely/utils.py
@@ -151,8 +151,11 @@ def run_docker(
         *cmd,
     ]
 
+    cmd = " ".join(docker_cmd)
     if verbose:
-        print(" ".join(docker_cmd))
+        print(cmd)
+    else:
+        debug(cmd)
 
     return subprocess.run(docker_cmd, *args, **kwargs)
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -1,6 +1,7 @@
 import os
 import pathlib
-from sys import platform
+import secrets
+import sys
 from unittest import mock
 
 import pytest
@@ -24,11 +25,14 @@ def test_jupyter(run, no_user, monkeypatch, version):
     mock_open_browser = mock.Mock(spec=utils.open_browser)
     monkeypatch.setattr(utils, "open_browser", mock_open_browser)
 
+    mock_token_hex = mock.Mock(spec=secrets.token_urlsafe)
+    mock_token_hex.return_value = "TOKEN"
+    monkeypatch.setattr(launch.secrets, "token_urlsafe", mock_token_hex)
+
     # these calls are done in different threads, so can come in any order
     run.concurrent = True
 
     run.expect(["docker", "info"])
-
     run.expect(
         [
             "docker",
@@ -46,6 +50,8 @@ def test_jupyter(run, no_user, monkeypatch, version):
             "HOME=/tmp",
             "--env",
             "PYTHONPATH=/workspace",
+            "--env",
+            "JUPYTER_TOKEN=TOKEN",
             f"ghcr.io/opensafely-core/python:{used_version}",
             "jupyter",
             "lab",
@@ -57,19 +63,6 @@ def test_jupyter(run, no_user, monkeypatch, version):
             "--LabApp.custom_display_url=http://localhost:1234/",
         ]
     )
-    # fetch the metadata
-    run.expect(
-        [
-            "docker",
-            "exec",
-            "test_jupyter",
-            "bash",
-            "-c",
-            "cat /tmp/.local/share/jupyter/runtime/*server-*.json",
-        ],
-        stdout='{"token": "TOKEN"}',
-    )
-
     assert run_main(launch, f"{tool} --port 1234 --name test_jupyter") == 0
     mock_open_browser.assert_called_with("http://localhost:1234/?token=TOKEN")
 
@@ -99,7 +92,7 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists, version):
     if gitconfig_exists:
         (home / ".gitconfig").touch()
 
-    if platform == "linux":
+    if sys.platform == "linux":
         uid = os.getuid()
     else:
         uid = None
@@ -128,7 +121,7 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists, version):
         "-p=8787:8787",
         "--name=test_rstudio",
         "--hostname=test_rstudio",
-        "--env=HOSTPLATFORM=" + platform,
+        "--env=HOSTPLATFORM=" + sys.platform,
         f"--env=HOSTUID={uid}",
     ]
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -102,15 +102,6 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists, version):
     run.expect(["docker", "info"])
 
     run.expect(["docker", "inspect", "test_rstudio"], returncode=1)
-    run.expect(
-        [
-            "docker",
-            "image",
-            "inspect",
-            f"ghcr.io/opensafely-core/rstudio:{used_version}",
-        ]
-    )
-
     expected = [
         "docker",
         "run",

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -137,7 +137,7 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists, version):
 @pytest.mark.parametrize("tool", ["jupyter", "rstudio"])
 @pytest.mark.functional
 def test_launch_browser(monkeypatch, docker, tool):
-    """This test's the --background flag, as well as providing base functional tests."""
+    """This tests the --background flag, as well as providing base functional tests."""
 
     mock_open_browser = mock.Mock(spec=utils.open_browser)
     monkeypatch.setattr(launch.utils, "open_browser", mock_open_browser)

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -59,10 +59,10 @@ def test_jupyter(run, no_user, monkeypatch, version):
             "lab",
             "--ip=0.0.0.0",
             "--port=1234",
-            "--allow-root",
             "--no-browser",
-            # display the url from the hosts perspective
-            "--LabApp.custom_display_url=http://localhost:1234/",
+            "--ServerApp.custom_display_url=http://localhost:1234/",
+            "-y",  # do not ask for confirmation on quiting
+            "--Application.log_level=ERROR",  # errors only please
         ]
     )
     assert run_main(launch, f"{tool} --port 1234 --name test_jupyter") == 0


### PR DESCRIPTION
To use `opensafely launch rstudio` in codespaces, we need to run in the background.  This is more complex than just adding `&` to the invocation, as docker client is actually forwarding stdin/out/err from the docker server - its pretending to be a process we control, but its not really (another reason we should look at podman). We need to use `docker run -d`. So this change adds a --background flag.  This is actually really useful for testing, and allows us to add fully functional tests of `opensafely launch` that were very tricky to write when running in the foreground.

In addition, it would be helpful to make launch command idempotent, so if you re-run it, you reconnect to the old running instance, which will preserve state between codespace use and provide better UX.  We add a --force to allow users recreate the session, which is maybe useful to ensure they are running the latest version of the image if needed.

There's also a few cleanups that made this work better, mainly bringing jupyter and rstudio implementations closer together, and removing some unneeded complexity.
