### PR TITLE
List project image versions

### DIFF
--- a/opensafely/info.py
+++ b/opensafely/info.py
@@ -1,3 +1,4 @@
+import argparse
 import json
 import subprocess
 
@@ -9,7 +10,14 @@ DESCRIPTION = "Print information about the opensafely tool and available resourc
 
 
 def add_arguments(parser):
-    pass
+    # developer tool to print the list of versions in project.yaml
+    parser.add_argument(
+        "--list-project-images",
+        nargs="?",  # Makes the value optional
+        const="project.yaml",  # Used when flag is present without value
+        default=None,  # Used when flag is absent
+        help=argparse.SUPPRESS,
+    )
 
 
 INFO = """
@@ -20,7 +28,14 @@ docker cpu: {cpu}
 """
 
 
-def main():
+def main(list_project_images=None):
+
+    if list_project_images is not None:
+        images = pull.get_actions_from_project_file(list_project_images)
+        # part of transitioning away from using :latest in project.yaml
+        print("\n".join(i.replace(":latest", ":v1") for i in sorted(images)))
+        return True
+
     print("System information:")
     try:
         ps = subprocess.run(
@@ -50,3 +65,5 @@ def main():
         for image, sha in sorted(local_images.items()):
             update = "(needs update)" if image in updates else "(latest version)"
             print(f" - {image:24}: {sha[7:15]} {update}")
+
+    return True

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -50,7 +50,10 @@ def add_arguments(parser):
     )
     parser.add_argument(
         "--project",
-        help="Use this project to yaml to decide which images to download",
+        nargs="?",  # Makes the value optional
+        const="project.yaml",  # Used when flag is present without value
+        default=None,  # Used when flag is absent
+        help="Use project.yaml to decide which images to download",
     )
 
 
@@ -60,7 +63,7 @@ def main(image="all", force=False, project=None):
 
     local_images = get_local_images()
 
-    if project:
+    if project is not None:
         force = True
         images = get_actions_from_project_file(project)
     elif image == "all":

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,0 +1,35 @@
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from opensafely import info
+
+
+project_fixture_path = Path(__file__).parent / "fixtures" / "projects"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Only runs on Linux")
+def test_info(capsys):
+    assert info.main()
+    out, err = capsys.readouterr()
+    assert "opensafely version:" in out
+    assert "docker version:" in out
+    assert "docker memory:" in out
+    assert "docker cpu:" in out
+
+
+def test_list_project_images(capsys):
+    assert info.main(list_project_images=project_fixture_path / "project.yaml")
+    out, err = capsys.readouterr()
+    assert err == ""
+    assert out == textwrap.dedent(
+        """
+       cohortextractor:v1
+       jupyter:v1
+       python:v1
+    """.lstrip(
+            "\n"
+        )
+    )

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -209,13 +209,14 @@ def test_get_actions_from_project_yaml_no_actions():
 @pytest.mark.parametrize(
     "argv,expected",
     [
-        ([], argparse.Namespace(image="all", force=False, project=None)),
-        (["--force"], argparse.Namespace(image="all", force=True, project=None)),
-        (["r"], argparse.Namespace(image="r", force=False, project=None)),
-        (["r", "--force"], argparse.Namespace(image="r", force=True, project=None)),
+        ([], dict(image="all", force=False, project=None)),
+        (["--force"], dict(image="all", force=True, project=None)),
+        (["r"], dict(image="r", force=False, project=None)),
+        (["r", "--force"], dict(image="r", force=True, project=None)),
+        (["--project"], dict(image="all", force=False, project="project.yaml")),
         (
             ["--project", "project.yaml"],
-            argparse.Namespace(image="all", force=False, project="project.yaml"),
+            dict(image="all", force=False, project="project.yaml"),
         ),
         (["invalid"], SystemExit()),
     ],
@@ -227,4 +228,4 @@ def test_pull_parser_valid(argv, expected, capsys):
         with pytest.raises(SystemExit):
             parser.parse_args(argv)
     else:
-        assert parser.parse_args(argv) == expected
+        assert parser.parse_args(argv) == argparse.Namespace(**expected)


### PR DESCRIPTION
Add `opensafely info --list-project-images [project.yaml]` command to print a list of all image versions.

This can be consumed by the codespaces tooling to know what runtime environments to set up.