### PR TITLE
Allow `post-covid-cvd` study to use `appointments`

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -46,5 +46,7 @@ opensafely/post-covid-kidney-outcomes:
   allow: ['appointments']
 opensafely/winter-pressures-phase-II:
   allow: ['appointments']
+opensafely/post-covid-cvd:
+  allow: ['appointments']
 opensafely/ckd-post-covid-outcomes:
   allow: ['ukrr']


### PR DESCRIPTION
This was approved here:
https://bennettoxford.slack.com/archives/C02HJTL065A/p1740071960925689