### PR TITLE
Support rstudio in opensafely pull, and update default versions

### DIFF
--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -17,7 +17,8 @@ DESCRIPTION = (
 REGISTRY = config.DOCKER_REGISTRY
 # The deprecated `databuilder` name is still supported by job-runner, but we don't want
 # it showing up here
-IMAGES = list(config.ALLOWED_IMAGES - {"databuilder"})
+# Rstudio image is local only, not used in production
+IMAGES = list(config.ALLOWED_IMAGES - {"databuilder"}) + ["rstudio"]
 DEPRECATED_REGISTRIES = ["docker.opensafely.org", "ghcr.io/opensafely"]
 IMAGES.sort()  # this is just for consistency for testing
 
@@ -164,7 +165,7 @@ def remove_deprecated_images(local_images):
 
 
 def get_default_version_for_image(name):
-    if name in ["python", "r"]:
+    if name in ["python", "r", "rstudio"]:
         return "v2"
     elif name == "cohortextractor":
         return "latest"

--- a/opensafely/pull.py
+++ b/opensafely/pull.py
@@ -164,12 +164,12 @@ def remove_deprecated_images(local_images):
 
 
 def get_default_version_for_image(name):
-    if name in ["ehrql"]:
-        return "v1"
-    elif name == "python":
+    if name in ["python", "r"]:
         return "v2"
-    else:
+    elif name == "cohortextractor":
         return "latest"
+    else:
+        return "v1"
 
 
 session = requests.Session()

--- a/tests/fixtures/projects/project.yaml
+++ b/tests/fixtures/projects/project.yaml
@@ -4,18 +4,13 @@ expectations:
   population_size: 1000
 
 actions:
-  cohortextractor:
-    run: cohortextractor:latest generate_cohort --study-definition study_definition
+  ehrql:
+    run: ehrql:v1 generate-dataset --output output/a.arrow
     outputs:
       highly_sensitive:
-        cohort: output/a.csv
+        cohort: output/a.arrow
   python:
-    run: python:latest touch output/b.csv
+    run: python:v2 touch output/b.csv
     outputs:
       highly_sensitive:
         cohort: output/b.csv
-  jupyter:
-    run: jupyter:latest touch output/c.csv
-    outputs:
-      highly_sensitive:
-        cohort: output/c.csv

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -26,9 +26,8 @@ def test_list_project_images(capsys):
     assert err == ""
     assert out == textwrap.dedent(
         """
-       cohortextractor:v1
-       jupyter:v1
-       python:v1
+       ehrql:v1
+       python:v2
     """.lstrip(
             "\n"
         )

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -40,7 +40,7 @@ def test_warn_if_updates_needed_images_outdated(capsys, monkeypatch, tmp_path, r
     monkeypatch.setattr(opensafely, "VERSION_FILE", tmp_path / "timestamp")
     expect_local_images(
         run,
-        stdout="ghcr.io/opensafely-core/python:latest=sha256:oldsha",
+        stdout="ghcr.io/opensafely-core/python:v1=sha256:oldsha",
     )
 
     opensafely.warn_if_updates_needed(["opensafely"])
@@ -48,7 +48,7 @@ def test_warn_if_updates_needed_images_outdated(capsys, monkeypatch, tmp_path, r
     out, err = capsys.readouterr()
     assert out == ""
     assert err.splitlines() == [
-        "Warning: the OpenSAFELY docker images for python:latest actions are out of date - please update by running:",
+        "Warning: the OpenSAFELY docker images for python:v1 actions are out of date - please update by running:",
         "    opensafely pull",
         "",
     ]

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -9,7 +9,7 @@ from opensafely import pull
 project_fixture_path = Path(__file__).parent / "fixtures" / "projects"
 
 
-def tag(image, version="latest"):
+def tag(image, version="v1"):
     return f"{pull.REGISTRY}/{image}:{version}"
 
 
@@ -44,11 +44,11 @@ def test_default_no_local_images(run, capsys):
 def test_default_no_local_images_force(run, capsys):
     run.expect(["docker", "info"])
     expect_local_images(run)
-    run.expect(["docker", "pull", tag("cohortextractor")])
-    run.expect(["docker", "pull", tag("ehrql", version="v1")])
+    run.expect(["docker", "pull", tag("cohortextractor", version="latest")])
+    run.expect(["docker", "pull", tag("ehrql")])
     run.expect(["docker", "pull", tag("jupyter")])
     run.expect(["docker", "pull", tag("python", version="v2")])
-    run.expect(["docker", "pull", tag("r")])
+    run.expect(["docker", "pull", tag("r", version="v2")])
     run.expect(["docker", "pull", tag("sqlrunner")])
     run.expect(["docker", "pull", tag("stata-mp")])
     run.expect(
@@ -68,19 +68,19 @@ def test_default_no_local_images_force(run, capsys):
     assert out.splitlines() == [
         "Updating OpenSAFELY cohortextractor:latest image",
         "Updating OpenSAFELY ehrql:v1 image",
-        "Updating OpenSAFELY jupyter:latest image",
+        "Updating OpenSAFELY jupyter:v1 image",
         "Updating OpenSAFELY python:v2 image",
-        "Updating OpenSAFELY r:latest image",
-        "Updating OpenSAFELY sqlrunner:latest image",
-        "Updating OpenSAFELY stata-mp:latest image",
+        "Updating OpenSAFELY r:v2 image",
+        "Updating OpenSAFELY sqlrunner:v1 image",
+        "Updating OpenSAFELY stata-mp:v1 image",
         "Pruning old OpenSAFELY docker images...",
     ]
 
 
 def test_default_with_local_images(run, capsys):
     run.expect(["docker", "info"])
-    expect_local_images(run, stdout="ghcr.io/opensafely-core/r:latest=sha")
-    run.expect(["docker", "pull", tag("r")])
+    expect_local_images(run, stdout="ghcr.io/opensafely-core/r:v2=sha")
+    run.expect(["docker", "pull", tag("r", version="v2")])
     run.expect(
         [
             "docker",
@@ -96,7 +96,7 @@ def test_default_with_local_images(run, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out.splitlines() == [
-        "Updating OpenSAFELY r:latest image",
+        "Updating OpenSAFELY r:v2 image",
         "Pruning old OpenSAFELY docker images...",
     ]
 
@@ -114,7 +114,7 @@ def test_default_with_old_docker(run, capsys):
 def test_specific_image(run, capsys):
     run.expect(["docker", "info"])
     expect_local_images(run)
-    run.expect(["docker", "pull", tag("r")])
+    run.expect(["docker", "pull", tag("r", version="v2")])
     run.expect(
         [
             "docker",
@@ -130,7 +130,7 @@ def test_specific_image(run, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out.splitlines() == [
-        "Updating OpenSAFELY r:latest image",
+        "Updating OpenSAFELY r:v2 image",
         "Pruning old OpenSAFELY docker images...",
     ]
 
@@ -138,9 +138,8 @@ def test_specific_image(run, capsys):
 def test_project(run, capsys):
     run.expect(["docker", "info"])
     expect_local_images(run)
-    run.expect(["docker", "pull", tag("cohortextractor")])
-    run.expect(["docker", "pull", tag("python")])
-    run.expect(["docker", "pull", tag("jupyter")])
+    run.expect(["docker", "pull", tag("ehrql")])
+    run.expect(["docker", "pull", tag("python", version="v2")])
     run.expect(
         [
             "docker",
@@ -156,9 +155,8 @@ def test_project(run, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out.splitlines() == [
-        "Updating OpenSAFELY cohortextractor:latest image",
-        "Updating OpenSAFELY python:latest image",
-        "Updating OpenSAFELY jupyter:latest image",
+        "Updating OpenSAFELY ehrql:v1 image",
+        "Updating OpenSAFELY python:v2 image",
         "Pruning old OpenSAFELY docker images...",
     ]
 
@@ -181,7 +179,7 @@ def test_remove_deprecated_images(run):
 def test_check_version_out_of_date(run):
     expect_local_images(
         run,
-        stdout="ghcr.io/opensafely-core/python:latest=sha256:oldsha",
+        stdout="ghcr.io/opensafely-core/python:v1=sha256:oldsha",
     )
     assert len(pull.check_version()) == 1
 
@@ -191,7 +189,7 @@ def test_check_version_up_to_date(run):
     pull.token = None
     expect_local_images(
         run,
-        stdout=f"ghcr.io/opensafely-core/python:latest={current_sha}",
+        stdout=f"ghcr.io/opensafely-core/python:v1={current_sha}",
     )
 
     assert len(pull.check_version()) == 0

--- a/tests/test_pull.py
+++ b/tests/test_pull.py
@@ -49,6 +49,7 @@ def test_default_no_local_images_force(run, capsys):
     run.expect(["docker", "pull", tag("jupyter")])
     run.expect(["docker", "pull", tag("python", version="v2")])
     run.expect(["docker", "pull", tag("r", version="v2")])
+    run.expect(["docker", "pull", tag("rstudio", version="v2")])
     run.expect(["docker", "pull", tag("sqlrunner")])
     run.expect(["docker", "pull", tag("stata-mp")])
     run.expect(
@@ -71,6 +72,7 @@ def test_default_no_local_images_force(run, capsys):
         "Updating OpenSAFELY jupyter:v1 image",
         "Updating OpenSAFELY python:v2 image",
         "Updating OpenSAFELY r:v2 image",
+        "Updating OpenSAFELY rstudio:v2 image",
         "Updating OpenSAFELY sqlrunner:v1 image",
         "Updating OpenSAFELY stata-mp:v1 image",
         "Pruning old OpenSAFELY docker images...",


### PR DESCRIPTION
Some fixes to the pull command
- switch the default pulled versions to use v1 rather than latest, bump r's default to v2
- support pulling rstudio images, and default to v2