### PR TITLE
Handle draft codelists

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -151,6 +151,16 @@ def fetch_codelist(codelist):
     try:
         response = requests.get(codelist.download_url)
         response.raise_for_status()
+        content_type = response.headers["content-type"]
+        if content_type != "text/csv":
+            if "this version is a draft" in response.text.lower():
+                exit_with_error(
+                    f"Codelist at:\n{codelist.url}\n"
+                    "is a draft codelist and cannot be added."
+                )
+            else:
+                raise ValueError("No codelist found at URL")
+
     except Exception as e:
         exit_with_error(
             f"Error downloading codelist: {e}\n\n"

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -350,3 +350,83 @@ def test_codelists_add_with_invalid_url(codelists_path):
 
     with pytest.raises(SystemExit):
         codelists.add("https://example.com/codelists/test/")
+
+
+def test_codelists_add_with_draft_url(codelists_path, requests_mock, capsys):
+    codelists_path /= "codelists"
+    codelists_file = codelists_path / "codelists.txt"
+    prior_codelists = codelists_file.read_text()
+    for codelist in prior_codelists.splitlines():
+        requests_mock.get(
+            f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
+            text="foo",
+        )
+    requests_mock.get(
+        "https://www.opencodelists.org/"
+        "codelist/project123/codelist456/version1/download.csv",
+        text="""
+            <!DOCTYPE html>
+            <html lang="en" class="h-100">
+            <head>
+            <meta charset="utf-8" />
+            <title>OpenCodelists: Test Codelist 456 (Draft)</title>
+            </head>
+            <body>
+            <div>
+                <h1 class="h3">Test Codelist 456</h1>
+                <p class="text-muted">This version is a draft</p>
+            </div>
+            </body>
+            </html>
+        """,
+        headers={"content-type": "text/html; charset=utf-8"},
+    )
+
+    with pytest.raises(SystemExit):
+        codelists.add(
+            "https://www.opencodelists.org/codelist/project123/codelist456/version1",
+            codelists_path,
+        )
+    stdout, _ = capsys.readouterr()
+    assert "is a draft codelist and cannot be added" in stdout
+
+
+def test_codelists_add_with_valid_non_codelist_url(
+    codelists_path, requests_mock, capsys
+):
+    codelists_path /= "codelists"
+    codelists_file = codelists_path / "codelists.txt"
+    prior_codelists = codelists_file.read_text()
+    for codelist in prior_codelists.splitlines():
+        requests_mock.get(
+            f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
+            text="foo",
+        )
+    requests_mock.get(
+        "https://www.opencodelists.org/"
+        "codelist/project123/codelist456/version1/download.csv",
+        text="""
+            <!DOCTYPE html>
+            <html lang="en" class="h-100">
+            <head>
+            <meta charset="utf-8" />
+            <title>Some Other Page</title>
+            </head>
+            <body>
+            <div>
+                <h1 class="h3">This is not a codelist</h1>
+                <p class="text-muted">It cannot meaningfully be downloaded</p>
+            </div>
+            </body>
+            </html>
+        """,
+        headers={"content-type": "text/html; charset=utf-8"},
+    )
+
+    with pytest.raises(SystemExit):
+        codelists.add(
+            "https://www.opencodelists.org/codelist/project123/codelist456/version1",
+            codelists_path,
+        )
+    stdout, _ = capsys.readouterr()
+    assert "No codelist found at URL" in stdout

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -48,11 +48,13 @@ def test_codelists_update(tmp_path, requests_mock):
         "https://www.opencodelists.org/"
         "codelist/project123/codelist456/version2/download.csv",
         text="foo",
+        headers={"content-type": "text/csv"},
     )
     requests_mock.get(
         "https://www.opencodelists.org/"
         "codelist/user/user123/codelist098/version1/download.csv",
         text="bar",
+        headers={"content-type": "text/csv"},
     )
     codelists.update()
     assert (codelist_dir / "project123-codelist456.csv").read_text() == "foo"
@@ -270,11 +272,13 @@ def test_codelists_add(codelists_path, requests_mock):
         requests_mock.get(
             f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
             text="foo",
+            headers={"content-type": "text/csv"},
         )
     requests_mock.get(
         "https://www.opencodelists.org/"
         "codelist/project123/codelist456/version1/download.csv",
         text="foo",
+        headers={"content-type": "text/csv"},
     )
 
     codelists.add(
@@ -298,11 +302,13 @@ def test_codelists_add_with_anchor_url(codelists_path, requests_mock):
             requests_mock.get(
                 f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
                 text="foo",
+                headers={"content-type": "text/csv"},
             )
     requests_mock.get(
         "https://www.opencodelists.org/"
         "codelist/project123/codelist456/version1/download.csv",
         text="foo",
+        headers={"content-type": "text/csv"},
     )
 
     codelists.add(
@@ -326,11 +332,13 @@ def test_codelists_add_with_download_url(codelists_path, requests_mock):
             requests_mock.get(
                 f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
                 text="foo",
+                headers={"content-type": "text/csv"},
             )
     requests_mock.get(
         "https://www.opencodelists.org/"
         "codelist/project123/codelist456/version1/download.csv",
         text="foo",
+        headers={"content-type": "text/csv"},
     )
 
     codelists.add(


### PR DESCRIPTION
Previously it was nearly impossible to add a draft codelist to codelists.txt as going to the URL in a browser would redirect to that codelist's builder URL, which would not pass the URL pattern validation.

Copying the draft codelist URL from a user's codelists page and then adding this to codelist.txt manually or via `codelists add` bypasses this block.

When a csv download of a draft codelist is requested from opencodelists it returns the HTML page for that codelist along with text stating its draft status, which the CLI would willingly put into a csv file in the codelists directory.

We don't want this behaviour and we don't want users to add draft codelists to projects as they are still mutable at this point.

This change checks for draft codelists and prevents their download.

Fixes #319 