### PR TITLE
Expand dataset checks to cover function calls in ehrQL

### DIFF
--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -139,8 +139,8 @@ def check_ehrql_datasets(files_to_check, datasets_to_check):
         if (
             dataset_check := check_restricted_names(
                 restricted_names=dataset.ehrql_names,
-                # Check for the use of `table_name.`
-                regex_template=r"\b{name}\.",
+                # Check for the use of `name.` or `name(`
+                regex_template=r"\b{name}(\.|\()",
                 files_to_check=files_to_check,
             )
         )

--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -18,7 +18,7 @@ DESCRIPTION = "Check the opensafely project for correctness"
 class RestrictedDataset:
     name: str
     cohort_extractor_function_names: List[str]
-    ehrql_table_names: List[str]
+    ehrql_names: List[str]
 
 
 RESTRICTED_DATASETS = [
@@ -27,48 +27,48 @@ RESTRICTED_DATASETS = [
         cohort_extractor_function_names=[
             "admitted_to_icu",
         ],
-        ehrql_table_names=[],
+        ehrql_names=[],
     ),
     RestrictedDataset(
         name="isaric",
         cohort_extractor_function_names=[
             "with_an_isaric_record",
         ],
-        ehrql_table_names=["isaric_new"],
+        ehrql_names=["isaric_new"],
     ),
     RestrictedDataset(
         name="ukrr",
         cohort_extractor_function_names=[
             "with_record_in_ukrr",
         ],
-        ehrql_table_names=["ukrr"],
+        ehrql_names=["ukrr"],
     ),
     RestrictedDataset(
         name="icnarc",
         cohort_extractor_function_names=[
             "admitted_to_icu",
         ],
-        ehrql_table_names=[],
+        ehrql_names=[],
     ),
     RestrictedDataset(
         name="open_prompt",
         cohort_extractor_function_names=[],
-        ehrql_table_names=["open_prompt"],
+        ehrql_names=["open_prompt"],
     ),
     RestrictedDataset(
         name="wl_clockstops",
         cohort_extractor_function_names=[],
-        ehrql_table_names=["wl_clockstops", "wl_clockstops_raw"],
+        ehrql_names=["wl_clockstops", "wl_clockstops_raw"],
     ),
     RestrictedDataset(
         name="wl_openpathways",
         cohort_extractor_function_names=[],
-        ehrql_table_names=["wl_openpathways", "wl_openpathways_raw"],
+        ehrql_names=["wl_openpathways", "wl_openpathways_raw"],
     ),
     RestrictedDataset(
         name="appointments",
         cohort_extractor_function_names=["with_gp_consultations"],
-        ehrql_table_names=["appointments"],
+        ehrql_names=["appointments"],
     ),
 ]
 
@@ -113,7 +113,7 @@ def main(continue_on_error=False):
         for dataset in datasets_to_check
         if (
             dataset_check := check_restricted_names(
-                restricted_names=dataset.ehrql_table_names,
+                restricted_names=dataset.ehrql_names,
                 # Check for the use of `table_name.`
                 regex_template=r"{name}\.",
                 files_to_check=files_to_check,

--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -95,31 +95,8 @@ def main(continue_on_error=False):
         if dataset.name not in allowed_datasets
     ]
 
-    found_cohort_datasets = {
-        dataset.name: dataset_check
-        for dataset in datasets_to_check
-        if (
-            dataset_check := check_restricted_names(
-                restricted_names=dataset.cohort_extractor_function_names,
-                # Check for the use of `.function_name`.
-                regex_template=r"\.{name}\(",
-                files_to_check=files_to_check,
-            )
-        )
-    }
-
-    found_ehrql_datasets = {
-        dataset.name: dataset_check
-        for dataset in datasets_to_check
-        if (
-            dataset_check := check_restricted_names(
-                restricted_names=dataset.ehrql_names,
-                # Check for the use of `table_name.`
-                regex_template=r"{name}\.",
-                files_to_check=files_to_check,
-            )
-        )
-    }
+    found_cohort_datasets = check_cohort_datasets(files_to_check, datasets_to_check)
+    found_ehrql_datasets = check_ehrql_datasets(files_to_check, datasets_to_check)
 
     violations = []
 
@@ -138,6 +115,36 @@ def main(continue_on_error=False):
     else:
         if not continue_on_error:
             print("Success")
+
+
+def check_cohort_datasets(files_to_check, datasets_to_check):
+    return {
+        dataset.name: dataset_check
+        for dataset in datasets_to_check
+        if (
+            dataset_check := check_restricted_names(
+                restricted_names=dataset.cohort_extractor_function_names,
+                # Check for the use of `.function_name`.
+                regex_template=r"\.{name}\(",
+                files_to_check=files_to_check,
+            )
+        )
+    }
+
+
+def check_ehrql_datasets(files_to_check, datasets_to_check):
+    return {
+        dataset.name: dataset_check
+        for dataset in datasets_to_check
+        if (
+            dataset_check := check_restricted_names(
+                restricted_names=dataset.ehrql_names,
+                # Check for the use of `table_name.`
+                regex_template=r"{name}\.",
+                files_to_check=files_to_check,
+            )
+        )
+    }
 
 
 def format_cohort_violations(found_datasets):

--- a/opensafely/check.py
+++ b/opensafely/check.py
@@ -140,7 +140,7 @@ def check_ehrql_datasets(files_to_check, datasets_to_check):
             dataset_check := check_restricted_names(
                 restricted_names=dataset.ehrql_names,
                 # Check for the use of `table_name.`
-                regex_template=r"{name}\.",
+                regex_template=r"\b{name}\.",
                 files_to_check=files_to_check,
             )
         )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -413,7 +413,7 @@ def test_check_cohort_datasets(
         ("bad_name", "bad_name", False),
         ("bad_name.", "bad_name", True),
         ("module.bad_name.", "bad_name", True),
-        ("not_a_bad_name.", "bad_name", True),
+        ("not_a_bad_name.", "bad_name", False),
         ("# bad_name.", "bad_name", False),
     ],
 )

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -129,7 +129,7 @@ def write_study_def(path, include_restricted):
 def write_dataset_def(path, include_restricted):
     filename_part = "restricted" if include_restricted else "unrestricted"
     all_restricted_tables = flatten_list(
-        [dataset.ehrql_table_names for dataset in check.RESTRICTED_DATASETS]
+        [dataset.ehrql_names for dataset in check.RESTRICTED_DATASETS]
     )
 
     for a in [1, 2]:
@@ -202,7 +202,7 @@ def validate_fail(capsys, continue_on_error, permissions):
                     assert dataset.name in stderr, permissions
                     assert f"{function_name}_name" in stderr
 
-            for table_name in dataset.ehrql_table_names:
+            for table_name in dataset.ehrql_names:
                 # commented out tables are never in error output, even if restricted
                 assert f"#{table_name}_commented" not in stderr
                 if dataset.name in permissions:

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -412,8 +412,10 @@ def test_check_cohort_datasets(
     [
         ("bad_name", "bad_name", False),
         ("bad_name.", "bad_name", True),
+        ("bad_name()", "bad_name", True),
         ("module.bad_name.", "bad_name", True),
-        ("not_a_bad_name.", "bad_name", False),
+        ("module.bad_name()", "bad_name", True),
+        ("not_a_bad_name()", "bad_name", False),
         ("# bad_name.", "bad_name", False),
     ],
 )


### PR DESCRIPTION
We're planning to add certain function/method calls to the restricted list in ehrQL and this adds the necessary mechanisms for doing so.