### PR TITLE
fix: ensure rstudio/python images exist before running launch command

### DIFF
--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -33,7 +33,12 @@ def test_jupyter(run, no_user, monkeypatch, version):
     run.concurrent = True
 
     run.expect(["docker", "info"])
+    # test if already running
     run.expect(["docker", "inspect", "test_jupyter"], returncode=1)
+
+    run.expect(
+        ["docker", "image", "inspect", f"ghcr.io/opensafely-core/python:{used_version}"]
+    )
     run.expect(
         [
             "docker",
@@ -100,8 +105,17 @@ def test_rstudio(run, tmp_path, monkeypatch, gitconfig_exists, version):
         uid = None
 
     run.expect(["docker", "info"])
-
+    # test if already running
     run.expect(["docker", "inspect", "test_rstudio"], returncode=1)
+
+    run.expect(
+        [
+            "docker",
+            "image",
+            "inspect",
+            f"ghcr.io/opensafely-core/rstudio:{used_version}",
+        ]
+    )
     expected = [
         "docker",
         "run",


### PR DESCRIPTION
If we let docker pull them lazily it causes two problems

- it can take so long that the open browser thread times out
- if the user ran in the background, then there is no output, and it
  looks like the command has hung

So, instead we ensure the relavnat image exists locally first, and if we
need to download it, we show that download output to the user
