### PR TITLE
Correct typo in repository name

### DIFF
--- a/repository_permissions.yaml
+++ b/repository_permissions.yaml
@@ -42,7 +42,7 @@ opensafely/post-covid-cvd:
   allow: ['appointments']
 opensafely/post-covid-cvd-methods:
   allow: ['appointments']
-opensafely/post-covid-covid-respiratory:
+opensafely/post-covid-respiratory:
   allow: ['appointments']
 opensafely/winter-pressures:
   allow: ['appointments']


### PR DESCRIPTION
Typo was added in this commit: d89501b682cb66dbdd2bbbc6287a87bfd9253b31

This contains a link to the original Slack thread approving access: https://bennettoxford.slack.com/archives/C02HJTL065A/p1740071960925689

Correct repository is here:
https://github.com/opensafely/post-covid-respiratory