### PR TITLE
Custom UA for contacting opencodelists.org

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -12,6 +12,7 @@ from opensafely._vendor import requests
 
 OPENCODELISTS_BASE_URL = "https://www.opencodelists.org"
 DESCRIPTION = f"Commands for interacting with {OPENCODELISTS_BASE_URL}"
+HEADERS = {"User-Agent": "OpenSAFELY CLI"}
 
 CODELISTS_DIR = "codelists"
 CODELISTS_FILE = "codelists.txt"
@@ -149,7 +150,7 @@ def write_manifest(codelists_dir, downloaded_codelists, append):
 
 def fetch_codelist(codelist):
     try:
-        response = requests.get(codelist.download_url)
+        response = requests.get(codelist.download_url, headers=HEADERS)
         response.raise_for_status()
         content_type = response.headers["content-type"]
         if content_type != "text/csv":
@@ -207,7 +208,7 @@ def check_upstream(codelists_dir=None):
         "manifest": manifest_file.read_text(),
     }
     url = f"{OPENCODELISTS_BASE_URL}/api/v1/check/"
-    response = requests.post(url, post_data).json()
+    response = requests.post(url, post_data, headers=HEADERS).json()
     status = response["status"]
 
     if status == "error":

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -7,16 +7,20 @@ import sys
 import tempfile
 from pathlib import Path
 
+import opensafely
 from opensafely._vendor import requests
 
 
 OPENCODELISTS_BASE_URL = "https://www.opencodelists.org"
 DESCRIPTION = f"Commands for interacting with {OPENCODELISTS_BASE_URL}"
-HEADERS = {"User-Agent": "OpenSAFELY CLI"}
 
 CODELISTS_DIR = "codelists"
 CODELISTS_FILE = "codelists.txt"
 MANIFEST_FILE = "codelists.json"
+
+
+def request_headers():
+    return {"User-Agent": f"OpenSAFELY-CLI/{opensafely.__version__.lstrip('v')}"}
 
 
 def add_arguments(parser):
@@ -150,7 +154,7 @@ def write_manifest(codelists_dir, downloaded_codelists, append):
 
 def fetch_codelist(codelist):
     try:
-        response = requests.get(codelist.download_url, headers=HEADERS)
+        response = requests.get(codelist.download_url, headers=request_headers())
         response.raise_for_status()
         content_type = response.headers["content-type"]
         if content_type != "text/csv":
@@ -208,7 +212,7 @@ def check_upstream(codelists_dir=None):
         "manifest": manifest_file.read_text(),
     }
     url = f"{OPENCODELISTS_BASE_URL}/api/v1/check/"
-    response = requests.post(url, post_data, headers=HEADERS).json()
+    response = requests.post(url, post_data, headers=request_headers()).json()
     status = response["status"]
 
     if status == "error":

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -454,23 +454,26 @@ def test_codelists_update_user_agent(requests_mock, tmp_path):
         "codelist/project123/codelist456/version2/download.csv",
         text="foo",
         headers={"content-type": "text/csv"},
-        request_headers=codelists.HEADERS,
+        request_headers=codelists.request_headers(),
     )
     requests_mock.get(
         "https://www.opencodelists.org/"
         "codelist/user/user123/codelist098/version1/download.csv",
         text="bar",
         headers={"content-type": "text/csv"},
-        request_headers=codelists.HEADERS,
+        request_headers=codelists.request_headers(),
     )
     assert codelists.update()
 
 
 def test_codelists_check_user_agent(mock_check, codelists_path):
-    mock_check(response={"status": "ok"}, request_headers=codelists.HEADERS)
+    mock_check(response={"status": "ok"}, request_headers=codelists.request_headers())
     os.chdir(codelists_path)
     assert codelists.check()
 
 
-def test_user_agent_value():
-    assert codelists.HEADERS["User-Agent"] == "OpenSAFELY CLI"
+def test_user_agent_value(set_current_version):
+    version = "v.1.0.0"
+    set_current_version(version)
+    headers = codelists.request_headers()
+    assert headers["User-Agent"] == f"OpenSAFELY-CLI/{version.lstrip('v')}"


### PR DESCRIPTION
Fixes #333 

We would like to enable Cloudflare's "bad bot" protections on OpenCodelists, `requests`'s standard UA of `python/requests` is flagged as a bot.

This PR introduces a bespoke user agent for OpenSAFELY CLI so that we can identify calls from the CLI