### PR TITLE
Add cooldown for Dependabot GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
   directory: "/"
   schedule:
     interval: "weekly"
+  cooldown:
+    default-days: 7


### PR DESCRIPTION
To match our dependency updates policy.