### PR TITLE
fix: actually test on python different versions in CI :facepalm:

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run tests on ${{ matrix.os }}
       if: ${{ matrix.os == 'ubuntu-22.04' }}
       run: |
-        echo "$PYTHON_VERSION"
+        export PYTHON_VERSION=python${{ matrix.python-version }}
         just test -vvv
 
     - name: Run tests on windows

--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ virtualenv:
     set -euo pipefail
 
     # allow users to specify python version in .env
-    PYTHON_VERSION=${PYTHON_VERSION:-python3.10}
+    PYTHON_VERSION=${PYTHON_VERSION:-python3.8}
 
     # create venv and upgrade pip
     test -d $VIRTUAL_ENV || { $PYTHON_VERSION -m venv $VIRTUAL_ENV && $PIP install --upgrade pip; }


### PR DESCRIPTION
Originally, this was attempting to fix breakage introduced by moving to `just build` in the publishing workflow, but fixing that uncovered that we a) were defaulting to 3.10 in dev rather than our minimum version, 3.8 and b) we were actually always testing on 3.10 on linux in CI, not the matrix python version.

This was an unintended side effect of this change: https://github.com/opensafely-core/opensafely-cli/commit/4412a99849ef955aeeb25198618fde183279fd7f

Moving from running `python -m pytest` to `just test` meant that we needed to specify PYTHON_VERSION env var to specify the version of python we are using, as we are using the just file's virtualenv machinery.

This is a `fix:` tagged release, rather than `chore:`, because it also (hopefully) fixes the release machinery which was broken for similar moving from direct python to just.
