### PR TITLE
Update Jobrunner local telemetry for consistency with production

### DIFF
--- a/opensafely/jobrunner/run.py
+++ b/opensafely/jobrunner/run.py
@@ -50,12 +50,11 @@ class ExecutorError(Exception):
 
 
 def main(exit_callback=lambda _: False):
-    log.info("jobrunner.run loop started")
+    log.debug("jobrunner.run loop started")
     api = get_executor_api()
 
     while True:
-        with tracer.start_as_current_span("LOOP", attributes={"loop": True}):
-            active_jobs = handle_jobs(api)
+        active_jobs = handle_jobs(api)
 
         if exit_callback(active_jobs):
             break

--- a/opensafely/jobrunner/run.py
+++ b/opensafely/jobrunner/run.py
@@ -183,12 +183,12 @@ def handle_single_job(job, api):
 def trace_handle_job(job, api, mode, paused):
     """Call handle job with tracing."""
     attrs = {
-        "initial_state": job.state.name,
-        "initial_code": job.status_code.name,
+        "job.initial_state": job.state.name,
+        "job.initial_code": job.status_code.name,
     }
 
     with tracer.start_as_current_span("LOOP_JOB") as span:
-        tracing.set_span_metadata(span, job, **attrs)
+        tracing.set_span_metadata(span, job, extra=attrs)
         try:
             synchronous_transition = handle_job(job, api, mode, paused)
         except Exception as exc:
@@ -196,8 +196,8 @@ def trace_handle_job(job, api, mode, paused):
             span.record_exception(exc)
             raise
         else:
-            span.set_attribute("final_state", job.state.name)
-            span.set_attribute("final_code", job.status_code.name)
+            span.set_attribute("job.final_state", job.state.name)
+            span.set_attribute("job.final_code", job.status_code.name)
 
     return synchronous_transition
 
@@ -641,7 +641,7 @@ def set_code(
 
         # job trace: we finished the previous state
         tracing.finish_current_state(
-            job, timestamp_ns, error=error, message=message, results=results, **attrs
+            job, timestamp_ns, error=error, results=results, **attrs
         )
 
         # update db object
@@ -659,7 +659,6 @@ def set_code(
                 job,
                 timestamp_ns,
                 error=error,
-                message=message,
                 results=results,
                 **attrs,
             )

--- a/opensafely/jobrunner/tracing.py
+++ b/opensafely/jobrunner/tracing.py
@@ -143,8 +143,6 @@ def finish_current_state(job, timestamp_ns, error=None, results=None, **attrs):
     if not _traceable(job):
         return
 
-    # allow them to be filtered out from tracking spans
-    attrs["is_state"] = True
     try:
         name = job.status_code.name
         start_time = job.status_code_updated_at

--- a/opensafely/jobrunner/tracing.py
+++ b/opensafely/jobrunner/tracing.py
@@ -1,6 +1,9 @@
 import logging
 import os
+import warnings
 from datetime import datetime
+
+from opensafely.jobrunner.models import StatusCode
 
 
 # we attempt to import the full otel machinery, which is present in dev, and if
@@ -138,7 +141,7 @@ def _traceable(job):
     return True
 
 
-def finish_current_state(job, timestamp_ns, error=None, results=None, **attrs):
+def finish_current_state(job, timestamp_ns, error=None, results=None, extra=None):
     """Record a span representing the state we've just exited."""
     if not _traceable(job):
         return
@@ -146,13 +149,13 @@ def finish_current_state(job, timestamp_ns, error=None, results=None, **attrs):
     try:
         name = job.status_code.name
         start_time = job.status_code_updated_at
-        record_job_span(job, name, start_time, timestamp_ns, error, results, **attrs)
+        record_job_span(job, name, start_time, timestamp_ns, error, results, extra)
     except Exception:
         # make sure trace failures do not error the job
         logger.exception(f"failed to trace state for {job.id}")
 
 
-def record_final_state(job, timestamp_ns, error=None, results=None, **attrs):
+def record_final_state(job, timestamp_ns, error=None, results=None, extra=None):
     """Record a span representing the state we've just exited."""
     if not _traceable(job):
         return
@@ -165,11 +168,10 @@ def record_final_state(job, timestamp_ns, error=None, results=None, **attrs):
         # final states have no duration, so make last for 1 sec, just act
         # as a marker
         end_time = int(timestamp_ns + 1e9)
-        record_job_span(
-            job, name, start_time, end_time, error, results, final=True, **attrs
-        )
+        extra = {"job.succeeded": job.status_code == StatusCode.SUCCEEDED}
+        record_job_span(job, name, start_time, end_time, error, results, extra)
 
-        complete_job(job, timestamp_ns, error, results, **attrs)
+        complete_job(job, timestamp_ns, error, results, extra)
     except Exception:
         # make sure trace failures do not error the job
         logger.exception(f"failed to trace state for {job.id}")
@@ -211,7 +213,7 @@ MINIMUM_NS_TIMESTAMP = int(datetime(2000, 1, 1, 0, 0, 0).timestamp() * 1e9)
 
 
 @warn_assertions
-def record_job_span(job, name, start_time, end_time, error, results, **attrs):
+def record_job_span(job, name, start_time, end_time, error, results, extra=None):
     """Record a span for a job."""
     if not _traceable(job):
         return
@@ -234,11 +236,11 @@ def record_job_span(job, name, start_time, end_time, error, results, **attrs):
     ctx = load_trace_context(job)
     tracer = trace.get_tracer("jobs")
     span = tracer.start_span(name, context=ctx, start_time=start_time)
-    set_span_metadata(span, job, error, results, **attrs)
+    set_span_metadata(span, job, error, results, extra)
     span.end(end_time)
 
 
-def complete_job(job, timestamp_ns, error=None, results=None, **attrs):
+def complete_job(job, timestamp_ns, error=None, results=None, extra=None):
     """Send the root span to record the full duration for this job."""
 
     root_ctx = load_root_span(job)
@@ -260,19 +262,26 @@ def complete_job(job, timestamp_ns, error=None, results=None, **attrs):
     root_span._context = root_ctx
 
     # annotate and send
-    set_span_metadata(root_span, job, error, results, **attrs)
+    set_span_metadata(root_span, job, error, results, extra)
     root_span.end(timestamp_ns)
 
 
 OTEL_ATTR_TYPES = (bool, str, bytes, int, float)
 
 
-def set_span_metadata(span, job, error=None, results=None, **attrs):
+def set_span_metadata(span, job, error=None, results=None, extra=None):
     """Set span metadata with everthing we know about a job."""
     attributes = {}
 
-    if attrs:
-        attributes.update(attrs)
+    if extra:
+        for k, v in extra.items():
+            # automatically give any additional attributes the job prefix if not already present
+            if not k.startswith("job."):  # pragma: nocover
+                # this will fail tests
+                warnings.warn(f"attribute {k} does not start with job. prefix")
+                # but correctly prefix it if somehow this happens for real.
+                k = "job." + k
+            attributes[k] = v
     attributes.update(trace_attributes(job, results))
 
     # opentelemetry can only handle serializing certain attribute types
@@ -309,46 +318,43 @@ def trace_attributes(job, results=None):
         except ValueError:
             job._job_request = {}
 
-    attrs = dict(
-        backend=config.BACKEND,
-        job=job.id,
-        job_request=job.job_request_id,
-        workspace=job.workspace,
-        action=job.action,
-        run_command=job.run_command,
-        user=job._job_request.get("created_by", "unknown"),
-        project=job._job_request.get("project", "unknown"),
-        orgs=",".join(job._job_request.get("orgs", [])),
-        state=job.state.name,
-        message=job.status_message,
+    # Note: no commit attribute because local_run jobs don't have a commit
+    attrs = {
+        "job.backend": config.BACKEND,
+        "job.id": job.id,
+        "job.request": job.job_request_id,
+        "job.workspace": job.workspace,
+        "job.action": job.action,
+        "job.run_command": job.run_command,
+        "job.user": job._job_request.get("created_by", "unknown"),
+        "job.project": job._job_request.get("project", "unknown"),
+        "job.orgs": ",".join(job._job_request.get("orgs", [])),
+        "job.state": job.state.name,
+        "job.message": job.status_message,
         # convert float seconds to ns integer
-        created_at=int(job.created_at * 1e9),
-        started_at=int(job.started_at * 1e9) if job.started_at else None,
+        "job.created_at": int(job.created_at * 1e9),
+        "job.started_at": int(job.started_at * 1e9) if job.started_at else None,
         # when did the state last change?
-        status_code_updated_at=job.status_code_updated_at,
-        requires_db=job.requires_db,
-    )
-
-    # local_run jobs don't have a commit
-    if job.commit:
-        attrs["commit"] = job.commit
+        "job.status_code_updated_at": job.status_code_updated_at,
+        "job.requires_db": job.requires_db,
+    }
 
     if job.action_repo_url:
-        attrs["reusable_action"] = job.action_repo_url
+        attrs["job.reusable_action"] = job.action_repo_url
         if job.action_commit:
-            attrs["reusable_action"] += ":" + job.action_commit
+            attrs["job.reusable_action"] += ":" + job.action_commit
 
     if results:
-        attrs["exit_code"] = results.exit_code
-        attrs["image_id"] = results.image_id
-        attrs["outputs"] = len(results.outputs)
-        attrs["unmatched_patterns"] = len(results.unmatched_patterns)
-        attrs["unmatched_outputs"] = len(results.unmatched_outputs)
-        attrs["executor_message"] = results.message
-        attrs["action_version"] = results.action_version
-        attrs["action_revision"] = results.action_revision
-        attrs["action_created"] = results.action_created
-        attrs["base_revision"] = results.base_revision
-        attrs["base_created"] = results.base_created
+        attrs["job.exit_code"] = results.exit_code
+        attrs["job.image_id"] = results.image_id
+        attrs["job.outputs"] = len(results.outputs)
+        attrs["job.unmatched_patterns"] = len(results.unmatched_patterns)
+        attrs["job.unmatched_outputs"] = len(results.unmatched_outputs)
+        attrs["job.executor_message"] = results.message
+        attrs["job.action_version"] = results.action_version
+        attrs["job.action_revision"] = results.action_revision
+        attrs["job.action_created"] = results.action_created
+        attrs["job.base_revision"] = results.base_revision
+        attrs["job.base_created"] = results.base_created
 
     return attrs

--- a/tests/jobrunner/test_run.py
+++ b/tests/jobrunner/test_run.py
@@ -667,11 +667,11 @@ def test_handle_job_finalized_failed_exit_code(
     assert spans[-3].name == "FINALIZED"
     completed_span = spans[-2]
     assert completed_span.name == "NONZERO_EXIT"
-    assert completed_span.attributes["exit_code"] == exit_code
-    assert completed_span.attributes["outputs"] == 1
-    assert completed_span.attributes["unmatched_patterns"] == 0
-    assert completed_span.attributes["unmatched_outputs"] == 0
-    assert completed_span.attributes["image_id"] == "image_id"
+    assert completed_span.attributes["job.exit_code"] == exit_code
+    assert completed_span.attributes["job.outputs"] == 1
+    assert completed_span.attributes["job.unmatched_patterns"] == 0
+    assert completed_span.attributes["job.unmatched_outputs"] == 0
+    assert completed_span.attributes["job.image_id"] == "image_id"
     assert completed_span.status.status_code == trace.StatusCode.ERROR
     assert spans[-1].name == "JOB"
 
@@ -703,9 +703,9 @@ def test_handle_job_finalized_failed_unmatched_patterns(db):
     assert spans[-3].name == "FINALIZED"
     completed_span = spans[-2]
     assert completed_span.name == "UNMATCHED_PATTERNS"
-    assert completed_span.attributes["outputs"] == 1
-    assert completed_span.attributes["unmatched_patterns"] == 1
-    assert completed_span.attributes["unmatched_outputs"] == 1
+    assert completed_span.attributes["job.outputs"] == 1
+    assert completed_span.attributes["job.unmatched_patterns"] == 1
+    assert completed_span.attributes["job.unmatched_outputs"] == 1
     assert spans[-1].name == "JOB"
 
 
@@ -870,13 +870,13 @@ def test_handle_single_job_marks_as_failed(db, monkeypatch, capsys):
     spans = get_trace("loop")
     assert len(spans) == 1
     assert spans[0].name == "LOOP_JOB"
-    assert spans[0].attributes["job"] == job.id
-    assert spans[0].attributes["workspace"] == job.workspace
-    assert spans[0].attributes["user"] == job._job_request["created_by"]
-    assert spans[0].attributes["initial_code"] == "EXECUTED"
-    assert spans[0].attributes["initial_state"] == "RUNNING"
-    assert "final_code" not in spans[0].attributes
-    assert "final_state" not in spans[0].attributes
+    assert spans[0].attributes["job.id"] == job.id
+    assert spans[0].attributes["job.workspace"] == job.workspace
+    assert spans[0].attributes["job.user"] == job._job_request["created_by"]
+    assert spans[0].attributes["job.initial_code"] == "EXECUTED"
+    assert spans[0].attributes["job.initial_state"] == "RUNNING"
+    assert "job.final_code" not in spans[0].attributes
+    assert "job.final_state" not in spans[0].attributes
 
     # traceback and user message printed
     captured = capsys.readouterr()
@@ -1112,6 +1112,6 @@ def test_trace_handle_job_successful_transition(db):
 
     spans = get_trace("loop")
     assert len(spans) == 1
-    assert spans[0].attributes["job"] == job.id
-    assert spans[0].attributes["initial_code"] == "PREPARED"
-    assert spans[0].attributes["final_code"] == "EXECUTING"
+    assert spans[0].attributes["job.id"] == job.id
+    assert spans[0].attributes["job.initial_code"] == "PREPARED"
+    assert spans[0].attributes["job.final_code"] == "EXECUTING"

--- a/tests/jobrunner/test_tracing.py
+++ b/tests/jobrunner/test_tracing.py
@@ -91,36 +91,35 @@ def test_trace_attributes(db):
 
     attrs = tracing.trace_attributes(job, results)
 
-    assert attrs == dict(
-        backend="expectations",
-        job=job.id,
-        job_request=job.job_request_id,
-        workspace="workspace",
-        action="action",
-        commit="commit",
-        run_command=job.run_command,
-        user="testuser",
-        project="project",
-        orgs="org1,org2",
-        state="PENDING",
-        message="message",
-        created_at=int(job.created_at * 1e9),
-        started_at=None,
-        status_code_updated_at=job.status_code_updated_at,
-        reusable_action="action_repo:commit",
-        requires_db=False,
-        outputs=2,
-        unmatched_patterns=1,
-        unmatched_outputs=1,
-        exit_code=1,
-        image_id="image_id",
-        executor_message="message",
-        action_version="unknown",
-        action_revision="unknown",
-        action_created="unknown",
-        base_revision="unknown",
-        base_created="unknown",
-    )
+    assert attrs == {
+        "job.backend": "expectations",
+        "job.id": job.id,
+        "job.request": job.job_request_id,
+        "job.workspace": "workspace",
+        "job.action": "action",
+        "job.run_command": job.run_command,
+        "job.user": "testuser",
+        "job.project": "project",
+        "job.orgs": "org1,org2",
+        "job.state": "PENDING",
+        "job.message": "message",
+        "job.created_at": int(job.created_at * 1e9),
+        "job.started_at": None,
+        "job.status_code_updated_at": job.status_code_updated_at,
+        "job.reusable_action": "action_repo:commit",
+        "job.requires_db": False,
+        "job.outputs": 2,
+        "job.unmatched_outputs": 1,
+        "job.unmatched_patterns": 1,
+        "job.exit_code": 1,
+        "job.image_id": "image_id",
+        "job.executor_message": "message",
+        "job.action_version": "unknown",
+        "job.action_revision": "unknown",
+        "job.action_created": "unknown",
+        "job.base_revision": "unknown",
+        "job.base_created": "unknown",
+    }
 
 
 def test_trace_attributes_missing(db):
@@ -141,24 +140,23 @@ def test_trace_attributes_missing(db):
     )
 
     attrs = tracing.trace_attributes(job)
-
-    assert attrs == dict(
-        backend="expectations",
-        job=job.id,
-        job_request=job.job_request_id,
-        workspace="workspace",
-        action="action",
-        run_command=job.run_command,
-        user="testuser",
-        project="project",
-        orgs="org1,org2",
-        state="PENDING",
-        message="message",
-        created_at=int(job.created_at * 1e9),
-        started_at=None,
-        status_code_updated_at=job.status_code_updated_at,
-        requires_db=False,
-    )
+    assert attrs == {
+        "job.backend": "expectations",
+        "job.id": job.id,
+        "job.request": job.job_request_id,
+        "job.workspace": "workspace",
+        "job.action": "action",
+        "job.run_command": job.run_command,
+        "job.user": "testuser",
+        "job.project": "project",
+        "job.orgs": "org1,org2",
+        "job.state": "PENDING",
+        "job.message": "message",
+        "job.created_at": int(job.created_at * 1e9),
+        "job.started_at": None,
+        "job.status_code_updated_at": job.status_code_updated_at,
+        "job.requires_db": False,
+    }
 
 
 def test_tracing_resource_config():
@@ -209,15 +207,15 @@ def test_finish_current_state(db):
 
     ts = int(time.time() * 1e9)
 
-    tracing.finish_current_state(job, ts, results=results, extra="extra")
+    tracing.finish_current_state(job, ts, results=results, extra={"job.extra": "extra"})
 
     spans = get_trace("jobs")
     assert spans[-1].name == "CREATED"
     assert spans[-1].start_time == start_time
     assert spans[-1].end_time == ts
-    assert spans[-1].attributes["extra"] == "extra"
-    assert spans[-1].attributes["job"] == job.id
-    assert spans[-1].attributes["exit_code"] == 0
+    assert spans[-1].attributes["job.extra"] == "extra"
+    assert spans[-1].attributes["job.id"] == job.id
+    assert spans[-1].attributes["job.exit_code"] == 0
 
 
 def test_record_final_state(db):
@@ -228,9 +226,11 @@ def test_record_final_state(db):
 
     spans = get_trace("jobs")
     assert spans[-2].name == "SUCCEEDED"
-    assert spans[-2].attributes["exit_code"] == 0
+    assert spans[-2].attributes["job.exit_code"] == 0
+    assert spans[-2].attributes["job.succeeded"] is True
     assert spans[-1].name == "JOB"
-    assert spans[-1].attributes["exit_code"] == 0
+    assert spans[-1].attributes["job.exit_code"] == 0
+    assert spans[-1].attributes["job.succeeded"] is True
 
 
 def test_record_final_state_error(db):
@@ -245,14 +245,14 @@ def test_record_final_state_error(db):
     assert spans[-2].events[0].name == "exception"
     assert spans[-2].events[0].attributes["exception.message"] == "error"
     assert spans[-2].status.status_code == trace.StatusCode.ERROR
-    assert spans[-2].attributes["exit_code"] == 1
+    assert spans[-2].attributes["job.exit_code"] == 1
 
     assert spans[-1].name == "JOB"
     assert spans[-1].status.status_code.name == "ERROR"
     assert spans[-1].events[0].name == "exception"
     assert spans[-1].events[0].attributes["exception.message"] == "error"
     assert spans[-1].status.status_code == trace.StatusCode.ERROR
-    assert spans[-1].attributes["exit_code"] == 1
+    assert spans[-1].attributes["job.exit_code"] == 1
 
 
 def test_record_job_span_skips_uninitialized_job(db):
@@ -285,7 +285,7 @@ def test_complete_job(db):
         assert span.context.trace_id == ctx.trace_id
         assert span.context.span_id == ctx.span_id
         assert span.parent is None
-        assert span.attributes["exit_code"] == 1
+        assert span.attributes["job.exit_code"] == 1
 
 
 def test_set_span_metadata_attrs(db):
@@ -301,21 +301,23 @@ def test_set_span_metadata_attrs(db):
     tracing.set_span_metadata(
         span,
         job,
-        custom_attr=Test(),  # test that attr is added and the type coerced to string
-        state="should be ignored",  # test that we can't override core job attributes
+        extra={
+            "job.custom_attr": Test(),  # test that attr is added and the type coerced to string
+            "job.state": "should be ignored",  # test that we can't override core job attributes
+        },
     )
 
-    assert span.attributes["job"] == job.id
-    assert span.attributes["job_request"] == job.job_request_id
-    assert span.attributes["workspace"] == job.workspace
-    assert span.attributes["action"] == job.action
-    assert span.attributes["state"] == job.state.name  # not "should be ignored"
-    assert span.attributes["custom_attr"] == "test"
+    assert span.attributes["job.id"] == job.id
+    assert span.attributes["job.request"] == job.job_request_id
+    assert span.attributes["job.workspace"] == job.workspace
+    assert span.attributes["job.action"] == job.action
+    assert span.attributes["job.state"] == job.state.name  # not "should be ignored"
+    assert span.attributes["job.custom_attr"] == "test"
 
     # job request attrs
-    assert span.attributes["user"] == job_request.original["created_by"]
-    assert span.attributes["project"] == job_request.original["project"]
-    assert span.attributes["orgs"] == ",".join(job_request.original["orgs"])
+    assert span.attributes["job.user"] == job_request.original["created_by"]
+    assert span.attributes["job.project"] == job_request.original["project"]
+    assert span.attributes["job.orgs"] == ",".join(job_request.original["orgs"])
 
 
 def test_set_span_metadata_error(db):

--- a/tests/jobrunner/test_tracing.py
+++ b/tests/jobrunner/test_tracing.py
@@ -217,7 +217,6 @@ def test_finish_current_state(db):
     assert spans[-1].end_time == ts
     assert spans[-1].attributes["extra"] == "extra"
     assert spans[-1].attributes["job"] == job.id
-    assert spans[-1].attributes["is_state"] is True
     assert spans[-1].attributes["exit_code"] == 0
 
 


### PR DESCRIPTION
Remove the LOOP trace, which doesn't provide any useful info for local telemetry
Closes #382 

Update the tracing attributes to namespace with `job.` for consistency with production controller telemetry.
Closes #381

Latter changes largely follow [job-runner PR #1075](https://github.com/opensafely-core/job-runner/pull/1075)

