### PR TITLE
Add just recipes for updating vendored dependencies

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -15,11 +15,24 @@ The tool makes the process relatively painless. There are a few
 workarounds (crude string subsitutions) we need to apply which are all
 configured in [pyproject.toml](./pyproject.toml).
 
-To update vendored dependecies, run:
+To update vendored dependencies, run:
 
 ```
-./scripts/update.sh
+just update-vendored-dependencies
 ```
+
+### The opensafely-pipeline library
+
+The `opensafely-pipeline` library is not published as a pypi package. If you
+need to update it to a new version, run:
+
+```
+just update-pipeline
+```
+
+This will pull in the new pipeline version, update it in `requirements.prod.in`
+and `requirements.prod.txt`, and update the vendored dependencies.
+
 
 ## opensafely run
 

--- a/justfile
+++ b/justfile
@@ -66,20 +66,14 @@ update-vendored-dependencies: virtualenv requirements-prod
     echo "Removing all .so libraries"
     find opensafely/_vendor/ -name \*.so -exec rm {} \;
 
-# ensure prod requirements installed and up to date
-#prodenv: requirements-prod
-#    #!/usr/bin/env bash
-#    set -euo pipefail
-#    # exit if .txt file has not changed since we installed them (-nt == "newer than', but we negate with || to avoid error exit code)
-#    test requirements.prod.txt -nt $VIRTUAL_ENV/.prod || exit 0
-#
-#    $PIP install -r requirements.prod.txt
-#    touch $VIRTUAL_ENV/.prod
-
 
 # && dependencies are run after the recipe has run. Needs just>=0.9.9. This is
 # a killer feature over Makefiles.
-#
+
+# update to the latest version of the internal pipeline library
+update-pipeline: && requirements-prod update-vendored-dependencies
+    ./scripts/upgrade-pipeline.sh requirements.prod.in
+
 # ensure dev requirements installed and up to date
 devenv: requirements-dev && install-precommit
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ _compile src dst *args: virtualenv
     {{ COMPILE }} --output-file={{ dst }} {{ src }} {{ args }}
 
 
-# update *vendored* production dependencies. See DEVELOPERS.md.
+# update requirements.prod.txt if requirements.prod.in has changed
 requirements-prod *args:
     just _compile requirements.prod.in requirements.prod.txt --no-allow-unsafe {{ args }}
 
@@ -53,6 +53,18 @@ requirements-prod *args:
 requirements-dev *args: virtualenv
     just _compile requirements.dev.in requirements.dev.txt --allow-unsafe {{ args }}
 
+
+# update *vendored* production dependencies. See DEVELOPERS.md.
+update-vendored-dependencies: virtualenv requirements-prod
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    echo "Vendoring prod dependencies"
+    $BIN/vendoring sync -v
+
+    # clean up
+    echo "Removing all .so libraries"
+    find opensafely/_vendor/ -name \*.so -exec rm {} \;
 
 # ensure prod requirements installed and up to date
 #prodenv: requirements-prod

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-echo "Vendoring prod dependencies"
-vendoring sync -v
-
-# clean up
-echo "Removing all .so libraries"
-find opensafely/_vendor/ -name \*.so -exec rm {} \;

--- a/scripts/upgrade-pipeline.sh
+++ b/scripts/upgrade-pipeline.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -eu
+
+file=$1
+github_package_url="opensafely-pipeline@https://github.com/opensafely-core/pipeline/archive/refs/tags/"
+latest=$(git ls-remote -h --refs --tags --heads https://github.com/opensafely-core/pipeline | grep -o "v20.*$" | sort | tail -1)
+echo "Latest version of pipeline is $latest"
+
+# exit early if we are at the latest version
+if grep -q "$latest" "$file"; then
+    echo "$file already contains latest version"
+    exit
+fi
+
+sed -i "s#$github_package_url.*\.zip#$github_package_url$latest.zip#" "$file"
+echo "Updated $file to pipline $latest"


### PR DESCRIPTION
- add a copy of the upgrade-pipeline script used in other report
- move update vendored dependencies from script to a just recipe
- add recipe for updating pipeline which also updates vendored dependencies