### PR TITLE
fix: avoid deprecated UTC datetime helpers

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -4,7 +4,7 @@ import os
 import sys
 import tempfile
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from opensafely import (  # noqa: E402
@@ -56,7 +56,7 @@ def should_version_check():
     if not VERSION_FILE.exists():
         return True
 
-    four_hours_ago = datetime.utcnow() - timedelta(hours=4)
+    four_hours_ago = datetime.now(timezone.utc) - timedelta(hours=4)
 
     return VERSION_FILE.stat().st_mtime < four_hours_ago.timestamp()
 

--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -176,7 +176,8 @@ def fetch_codelist(codelist):
             f"Check that you can access the codelist at:\n{codelist.url}"
         )
     codelist.filename.write_bytes(response.content)
-    return (datetime.datetime.utcnow(), hash_bytes(response.content))
+    downloaded_at = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
+    return (downloaded_at, hash_bytes(response.content))
 
 
 def get_codelists_dir(codelists_dir=None):

--- a/opensafely/jobrunner/cli/local_run.py
+++ b/opensafely/jobrunner/cli/local_run.py
@@ -32,7 +32,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from opensafely._vendor.pipeline import (
@@ -632,8 +632,8 @@ def get_stata_license(repo=config.STATA_LICENSE_REPO):
 
     fetch = False
     if cached.exists():
-        mtime = datetime.fromtimestamp(cached.stat().st_mtime)
-        if datetime.utcnow() - mtime > license_timeout:
+        mtime = datetime.fromtimestamp(cached.stat().st_mtime, timezone.utc)
+        if datetime.now(timezone.utc) - mtime > license_timeout:
             fetch = True
     else:
         fetch = True
@@ -657,7 +657,7 @@ def get_stata_license(repo=config.STATA_LICENSE_REPO):
     if cached.exists():
         # if the refresh failed for some reason, update the last time it was
         # used to now to avoid spamming github on every subsequent run
-        t = datetime.utcnow().timestamp()
+        t = datetime.now(timezone.utc).timestamp()
         os.utime(cached, (t, t))
         return cached.read_text()
     else:

--- a/opensafely/jobrunner/models.py
+++ b/opensafely/jobrunner/models.py
@@ -349,7 +349,12 @@ def random_id():
 def timestamp_to_isoformat(ts):
     if ts is None:
         return None
-    return datetime.datetime.utcfromtimestamp(ts).isoformat() + "Z"
+    return (
+        datetime.datetime.fromtimestamp(ts, datetime.timezone.utc)
+        .replace(tzinfo=None)
+        .isoformat()
+        + "Z"
+    )
 
 
 def isoformat_to_timestamp(string):

--- a/tests/jobrunner/cli/test_local_run.py
+++ b/tests/jobrunner/cli/test_local_run.py
@@ -3,7 +3,7 @@ import logging
 import os
 import shutil
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -207,7 +207,7 @@ def test_get_stata_license_cache_recent(systmpdir, monkeypatch, tmp_path):
 def test_get_stata_license_cache_expired(systmpdir, tmp_path, license_repo):
     cache = tmp_path / "opensafely-stata.lic"
     cache.write_text("cached-license")
-    utime = (datetime.utcnow() - timedelta(hours=12)).timestamp()
+    utime = (datetime.now(timezone.utc) - timedelta(hours=12)).timestamp()
     os.utime(cache, (utime, utime))
 
     assert local_run.get_stata_license(license_repo) == "repo-license"

--- a/tests/jobrunner/lib/test_log_utils.py
+++ b/tests/jobrunner/lib/test_log_utils.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 
 from opensafely.jobrunner.cli import local_run
 from opensafely.jobrunner.lib import log_utils
@@ -7,7 +7,11 @@ from opensafely.jobrunner.models import Job, JobRequest
 
 
 FROZEN_TIMESTAMP = 1608568119.1467905
-FROZEN_TIMESTRING = datetime.utcfromtimestamp(FROZEN_TIMESTAMP).isoformat()
+FROZEN_TIMESTRING = (
+    datetime.fromtimestamp(FROZEN_TIMESTAMP, timezone.utc)
+    .replace(tzinfo=None)
+    .isoformat()
+)
 
 repo_url = "https://github.com/opensafely/project"
 test_job = Job(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,6 @@
 import os
 import warnings
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -15,7 +15,7 @@ def test_should_version_check():
     opensafely.update_version_check()
     assert opensafely.should_version_check() is False
 
-    timestamp = (datetime.utcnow() - timedelta(hours=5)).timestamp()
+    timestamp = (datetime.now(timezone.utc) - timedelta(hours=5)).timestamp()
     os.utime(opensafely.VERSION_FILE, (timestamp, timestamp))
 
     assert opensafely.should_version_check() is True


### PR DESCRIPTION
## Summary
- replace first-party `utcnow()` and `utcfromtimestamp()` calls with timezone-aware UTC equivalents
- keep existing naive UTC string output where callers currently append `Z`
- update related tests to avoid deprecated datetime helpers

Fixes #234.

## Validation
- Not run locally
- `rg -n utcnow|utcfromtimestamp opensafely tests --glob !opensafely/_vendor/**`
- `git diff --check`
- `git diff --cached --check`