### PR TITLE
Align pre-commit Python with .python-version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.8
 
 exclude: opensafely/_vendor/
 repos:


### PR DESCRIPTION
## Summary

Fixes #397.
Refs #396.

- Align `.pre-commit-config.yaml` with the project `.python-version` by changing the default pre-commit Python from `python3.10` to `python3.8`.
- This matches the repository's current Python 3.8 development/version target in `.python-version` and `pyproject.toml`.

## Validation

- `git diff --check`
- `rg -n 'python3\.8|python3\.10|requires-python|target-version|Programming Language :: Python :: 3\.8' .pre-commit-config.yaml .python-version pyproject.toml`
- Not run locally: pre-commit, tests, build, or install