### PR TITLE
Explain nondownloadable codelists

### DIFF
--- a/opensafely/codelists.py
+++ b/opensafely/codelists.py
@@ -159,6 +159,18 @@ def write_manifest(codelists_dir, downloaded_codelists, append):
 def fetch_codelist(codelist):
     try:
         response = requests.get(codelist.download_url, headers=request_headers())
+        if (
+            response.status_code == 400
+            and "codelist is not downloadable" in response.text.lower()
+        ):
+            exit_with_error(
+                f"Codelist at:\n{codelist.url}\n"
+                "is not downloadable from OpenCodelists.\n\n"
+                "This can happen when the codelist CSV does not contain a code "
+                "column header supported by its coding system. Check the "
+                "codelist page for details, or use a downloadable codelist "
+                "version."
+            )
         response.raise_for_status()
         content_type = response.headers["content-type"]
         if content_type != "text/csv":

--- a/tests/test_codelists.py
+++ b/tests/test_codelists.py
@@ -405,6 +405,35 @@ def test_codelists_add_with_draft_url(codelists_path, requests_mock, capsys):
     assert "is a draft codelist and cannot be added" in stdout
 
 
+def test_codelists_add_with_not_downloadable_url(
+    codelists_path, requests_mock, capsys
+):
+    codelists_path /= "codelists"
+    codelists_file = codelists_path / "codelists.txt"
+    prior_codelists = codelists_file.read_text()
+    for codelist in prior_codelists.splitlines():
+        requests_mock.get(
+            f"https://www.opencodelists.org/codelist/{codelist.rstrip('/')}/download.csv",
+            text="foo",
+        )
+    requests_mock.get(
+        "https://www.opencodelists.org/"
+        "codelist/project123/codelist456/version1/download.csv",
+        text="Codelist is not downloadable",
+        status_code=400,
+        headers={"content-type": "text/html; charset=utf-8"},
+    )
+
+    with pytest.raises(SystemExit):
+        codelists.add(
+            "https://www.opencodelists.org/codelist/project123/codelist456/version1",
+            codelists_path,
+        )
+    stdout, _ = capsys.readouterr()
+    assert "is not downloadable from OpenCodelists" in stdout
+    assert "code column header supported by its coding system" in stdout
+
+
 def test_codelists_add_with_valid_non_codelist_url(
     codelists_path, requests_mock, capsys
 ):


### PR DESCRIPTION
## Summary
- Detect OpenCodelists' 'Codelist is not downloadable' response before the generic HTTP error path.
- Show users a clearer explanation that unsupported code column headers can make a codelist version unavailable for download.
- Add coverage for the nondownloadable codelist response.

Fixes #373

## Validation
- Not run locally.