### PR TITLE
Add a warning message to legacy Python users

### DIFF
--- a/opensafely/__init__.py
+++ b/opensafely/__init__.py
@@ -66,6 +66,21 @@ def update_version_check():
     VERSION_FILE.touch()
 
 
+def warn_if_unsupported_python_version():
+    if sys.version_info < (3, 10):
+        print(
+            "Warning: The installed Python version being used to run the OpenSAFELY "
+            "CLI is older than Python 3.10 and has reached end of life.\n"
+            "\n"
+            "This installed version of the OpenSAFELY CLI will continue to run, but "
+            "you will no longer receive new versions of the OpenSAFELY CLI.\n"
+            "\n"
+            "Please upgrade your Python installation to ensure you can upgrade to "
+            "new versions of the OpenSAFELY CLI.\n",
+            file=sys.stderr,
+        )
+
+
 def warn_if_updates_needed(argv):
     # we only check for new versions periodically
     if not should_version_check():
@@ -158,6 +173,7 @@ def main():
     add_subcommand("jupyter", jupyter)
     add_subcommand("rstudio", rstudio)
 
+    warn_if_unsupported_python_version()
     warn_if_updates_needed(sys.argv)
     args = parser.parse_args()
     kwargs = vars(args)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,6 +8,14 @@ import opensafely
 from tests.test_pull import expect_local_images
 
 
+def test_warn_if_unsupported_python_version(capsys, monkeypatch):
+    monkeypatch.setattr(opensafely.sys, "version_info", (3, 9))
+
+    opensafely.warn_if_unsupported_python_version()
+
+    assert "older than Python 3.10" in capsys.readouterr().err
+
+
 def test_should_version_check():
     opensafely.VERSION_FILE.unlink(missing_ok=True)
 


### PR DESCRIPTION
Part of https://github.com/opensafely-core/opensafely-cli/issues/280

https://github.com/opensafely-core/opensafely-cli/pull/407 is going to remove the ability for users of legacy versions of Python to upgrade, so this final change provides them with a message alerting them to this fact, and telling them why it is happening.