### PR TITLE
fix: yaml incorrect parsing of Python version

### DIFF
--- a/.github/workflows/build_and_publish.yaml
+++ b/.github/workflows/build_and_publish.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Python 3.10
         uses: opensafely-core/setup-action@5b3030fbbcf069c94e352b4f0a94100fae4dbd82 # v1.6.1
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       - name: Generate correct value for VERSION file
         run: |


### PR DESCRIPTION
3.10 in yaml, without quotes, equals 3.1